### PR TITLE
change account unique constraint to battletag

### DIFF
--- a/src/main/java/com/nephest/battlenet/sc2/model/local/Account.java
+++ b/src/main/java/com/nephest/battlenet/sc2/model/local/Account.java
@@ -21,7 +21,6 @@
 package com.nephest.battlenet.sc2.model.local;
 
 import com.nephest.battlenet.sc2.model.BaseAccount;
-import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.blizzard.BlizzardAccount;
 
 import javax.validation.constraints.NotNull;
@@ -33,38 +32,30 @@ extends BaseAccount
 implements java.io.Serializable
 {
 
-    private static final long serialVersionUID = 1l;
+    private static final long serialVersionUID = 2L;
 
     private Long id;
-
-    @NotNull
-    private Region region;
-
-    @NotNull
-    private Long battlenetId;
 
     @NotNull
     private OffsetDateTime updated = OffsetDateTime.now();
 
     public Account(){}
 
-    public Account(Long id, Region region, Long battlenetId, String battleTag)
+    public Account(Long id, String battleTag)
     {
         super(battleTag);
         this.id = id;
-        this.region = region;
-        this.battlenetId = battlenetId;
     }
 
-    public static final Account of(Region region, BlizzardAccount bAccount)
+    public static final Account of(BlizzardAccount bAccount)
     {
-        return new Account(null, region, bAccount.getId(), bAccount.getBattleTag());
+        return new Account(null, bAccount.getBattleTag());
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(getRegion(), getBattlenetId());
+        return Objects.hash(getBattleTag());
     }
 
     @Override
@@ -75,8 +66,7 @@ implements java.io.Serializable
         if( !(other instanceof Account) ) return false;
 
         Account otherAccount = (Account) other;
-        return getRegion() == otherAccount.getRegion()
-            && getBattlenetId() == otherAccount.getBattlenetId();
+        return getBattleTag().equals(otherAccount.getBattleTag());
     }
 
     @Override
@@ -84,9 +74,9 @@ implements java.io.Serializable
     {
         return String.format
         (
-            "%s[%s %s]",
+            "%s[%s]",
             getClass().getSimpleName(),
-            getRegion().toString(), String.valueOf(getBattlenetId())
+            getBattleTag()
         );
     }
 
@@ -98,26 +88,6 @@ implements java.io.Serializable
     public Long getId()
     {
         return id;
-    }
-
-    public void setRegion(Region region)
-    {
-        this.region = region;
-    }
-
-    public Region getRegion()
-    {
-        return region;
-    }
-
-    public void setBattlenetId(Long battlenetId)
-    {
-        this.battlenetId = battlenetId;
-    }
-
-    public Long getBattlenetId()
-    {
-        return battlenetId;
     }
 
     public void setUpdated(OffsetDateTime updated)

--- a/src/main/java/com/nephest/battlenet/sc2/model/local/PlayerCharacter.java
+++ b/src/main/java/com/nephest/battlenet/sc2/model/local/PlayerCharacter.java
@@ -21,6 +21,7 @@
 package com.nephest.battlenet.sc2.model.local;
 
 import com.nephest.battlenet.sc2.model.BasePlayerCharacter;
+import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.blizzard.BlizzardPlayerCharacter;
 
 import javax.validation.constraints.NotNull;
@@ -31,7 +32,7 @@ extends BasePlayerCharacter
 implements java.io.Serializable
 {
 
-    private static final long serialVersionUID = 1l;
+    private static final long serialVersionUID = 2L;
 
     private Long id;
 
@@ -39,24 +40,29 @@ implements java.io.Serializable
     private Long accountId;
 
     @NotNull
+    private Region region;
+
+    @NotNull
     private Long battlenetId;
 
     public PlayerCharacter(){}
 
-    public PlayerCharacter(Long id, Long accountId, Long battlenetId, Integer realm, String name)
+    public PlayerCharacter(Long id, Long accountId, Region region, Long battlenetId, Integer realm, String name)
     {
         super(realm, name);
         this.id = id;
         this.accountId = accountId;
+        this.region = region;
         this.battlenetId = battlenetId;
     }
 
-    public static final PlayerCharacter of(Account account, BlizzardPlayerCharacter bCharacter)
+    public static final PlayerCharacter of(Account account, Region region, BlizzardPlayerCharacter bCharacter)
     {
         return new PlayerCharacter
         (
             null,
             account.getId(),
+            region,
             bCharacter.getId(),
             bCharacter.getRealm(),
             bCharacter.getName()
@@ -66,7 +72,7 @@ implements java.io.Serializable
     @Override
     public int hashCode()
     {
-        return Objects.hash(getAccountId(), getBattlenetId());
+        return Objects.hash(getRegion(), getBattlenetId());
     }
 
     @Override
@@ -77,8 +83,8 @@ implements java.io.Serializable
         if ( !(other instanceof PlayerCharacter) ) return false;
 
         PlayerCharacter otherPlayerCharacter = (PlayerCharacter) other;
-        return getAccountId() == otherPlayerCharacter.getAccountId()
-            && getBattlenetId() == otherPlayerCharacter.getBattlenetId();
+        return getRegion() == otherPlayerCharacter.getRegion()
+            && getBattlenetId().equals(otherPlayerCharacter.getBattlenetId());
     }
 
     @Override
@@ -88,7 +94,7 @@ implements java.io.Serializable
         (
             "%s[%s %s]",
             getClass().getSimpleName(),
-            String.valueOf(getAccountId()), String.valueOf(getBattlenetId())
+            getRegion().name(), getBattlenetId()
         );
     }
 
@@ -110,6 +116,16 @@ implements java.io.Serializable
     public Long getAccountId()
     {
         return accountId;
+    }
+
+    public Region getRegion()
+    {
+        return region;
+    }
+
+    public void setRegion(Region region)
+    {
+        this.region = region;
     }
 
     public void setBattlenetId(Long battlenetId)

--- a/src/main/java/com/nephest/battlenet/sc2/model/local/dao/AccountDAO.java
+++ b/src/main/java/com/nephest/battlenet/sc2/model/local/dao/AccountDAO.java
@@ -37,13 +37,12 @@ import java.util.Collections;
 public class AccountDAO
 {
     private static final String CREATE_QUERY = "INSERT INTO account "
-        + "(battlenet_id, region, battle_tag, updated) "
-        + "VALUES (:battlenetId, :region, :battleTag, :updated)";
+        + "(battle_tag, updated) "
+        + "VALUES (:battleTag, :updated)";
 
     private static final String MERGE_QUERY = CREATE_QUERY
         + " "
-        + "ON CONFLICT(region, battlenet_id) DO UPDATE SET "
-        + "battle_tag=excluded.battle_tag, "
+        + "ON CONFLICT(battle_tag) DO UPDATE SET "
         + "updated=excluded.updated";
 
     private static final String REMOVE_EXPIRED_PRIVACY_QUERY =
@@ -87,8 +86,6 @@ public class AccountDAO
     private MapSqlParameterSource createParameterSource(Account account)
     {
         return new MapSqlParameterSource()
-            .addValue("battlenetId", account.getBattlenetId())
-            .addValue("region", conversionService.convert(account.getRegion(), Integer.class))
             .addValue("battleTag", account.getBattleTag())
             .addValue("updated", account.getUpdated());
     }

--- a/src/main/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterDAO.java
+++ b/src/main/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterDAO.java
@@ -23,6 +23,7 @@ package com.nephest.battlenet.sc2.model.local.dao;
 import com.nephest.battlenet.sc2.model.local.PlayerCharacter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -33,24 +34,27 @@ import org.springframework.stereotype.Repository;
 public class PlayerCharacterDAO
 {
     private static final String CREATE_QUERY = "INSERT INTO player_character "
-        + "(account_id, battlenet_id, realm, name) "
-        + "VALUES (:accountId, :battlenetId, :realm, :name)";
+        + "(account_id, region, battlenet_id, realm, name) "
+        + "VALUES (:accountId, :region, :battlenetId, :realm, :name)";
 
     private static final String MERGE_QUERY = CREATE_QUERY
         + " "
-        + "ON CONFLICT(account_id, battlenet_id) DO UPDATE SET "
+        + "ON CONFLICT(region, battlenet_id) DO UPDATE SET "
         + "realm=excluded.realm, "
         + "name=excluded.name";
 
-    private NamedParameterJdbcTemplate template;
+    private final NamedParameterJdbcTemplate template;
+    private final ConversionService conversionService;
 
     @Autowired
     public PlayerCharacterDAO
     (
-        @Qualifier("sc2StatsNamedTemplate") NamedParameterJdbcTemplate template
+        @Qualifier("sc2StatsNamedTemplate") NamedParameterJdbcTemplate template,
+        @Qualifier("sc2StatsConversionService") ConversionService conversionService
     )
     {
         this.template = template;
+        this.conversionService = conversionService;
     }
 
     public PlayerCharacter create(PlayerCharacter character)
@@ -75,6 +79,7 @@ public class PlayerCharacterDAO
     {
         return new MapSqlParameterSource()
             .addValue("accountId", character.getAccountId())
+            .addValue("region", conversionService.convert(character.getRegion(), Integer.class))
             .addValue("battlenetId", character.getBattlenetId())
             .addValue("realm", character.getRealm())
             .addValue("name", character.getName());

--- a/src/main/java/com/nephest/battlenet/sc2/model/local/ladder/LadderDistinctCharacter.java
+++ b/src/main/java/com/nephest/battlenet/sc2/model/local/ladder/LadderDistinctCharacter.java
@@ -21,16 +21,12 @@
 package com.nephest.battlenet.sc2.model.local.ladder;
 
 import com.nephest.battlenet.sc2.model.BaseLeague;
-import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.local.PlayerCharacter;
 
 import javax.validation.constraints.NotNull;
 
 public class LadderDistinctCharacter
 {
-
-    @NotNull
-    private final Region region;
 
     @NotNull
     private final BaseLeague.LeagueType leagueMax;
@@ -46,7 +42,6 @@ public class LadderDistinctCharacter
 
     public LadderDistinctCharacter
     (
-        Region region,
         BaseLeague.LeagueType leagueMax,
         Integer ratingMax,
         String battleTag,
@@ -58,7 +53,6 @@ public class LadderDistinctCharacter
         Integer totalGamesPlayed
     )
     {
-        this.region = region;
         this.leagueMax = leagueMax;
         this.ratingMax = ratingMax;
         this.totalGamesPlayed = totalGamesPlayed;
@@ -71,11 +65,6 @@ public class LadderDistinctCharacter
             zergGamesPlayed,
             randomGamesPlayed
         );
-    }
-
-    public Region getRegion()
-    {
-        return region;
     }
 
     public BaseLeague.LeagueType getLeagueMax()

--- a/src/main/java/com/nephest/battlenet/sc2/model/local/ladder/dao/LadderSearchDAO.java
+++ b/src/main/java/com/nephest/battlenet/sc2/model/local/ladder/dao/LadderSearchDAO.java
@@ -98,12 +98,13 @@ public class LadderSearchDAO
 
     private static final String FIND_TEAM_MEMBERS_LATE_FORMAT =
         "SELECT "
-        + "team.region, "
+        + "team.region AS \"team.region\", "
         + "team.league_type, team.queue_type, team.team_type, "
         + "team.tier_type, "
         + "team.id as \"team.id\", team.rating, team.wins, team.losses, "
         + "account.id AS \"account.id\", account.battle_tag,"
         + "player_character.id AS \"player_character.id\", "
+        + "player_character.region AS \"player_character.region\", "
         + "player_character.battlenet_id AS \"player_character.battlenet_id\", player_character.realm, player_character.name, "
         + "team_member.terran_games_played, team_member.protoss_games_played, "
         + "team_member.zerg_games_played, team_member.random_games_played "
@@ -135,12 +136,13 @@ public class LadderSearchDAO
 
     private static final String FIND_TEAM_MEMBERS_FORMAT =
         "SELECT "
-        + "team.region, "
+        + "team.region AS \"team.region\", "
         + "team.league_type, team.queue_type, team.team_type, "
         + "team.tier_type, "
         + "team.id as \"team.id\", team.rating, team.wins, team.losses, "
         + "account.id AS \"account.id\", account.battle_tag,"
         + "player_character.id AS \"player_character.id\", "
+        + "player_character.region AS \"player_character.region\", "
         + "player_character.battlenet_id AS \"player_character.battlenet_id\", player_character.realm, player_character.name, "
         + "team_member.terran_games_played, team_member.protoss_games_played, "
         + "team_member.zerg_games_played, team_member.random_games_played "
@@ -158,12 +160,13 @@ public class LadderSearchDAO
 
     private static final String FIND_TEAM_MEMBERS_ANCHOR_FORMAT =
         "SELECT "
-        + "team.region, "
+        + "team.region AS \"team.region\", "
         + "team.league_type, team.queue_type, team.team_type, "
         + "team.tier_type, "
         + "team.id as \"team.id\", team.rating, team.wins, team.losses, "
         + "account.id AS \"account.id\", account.battle_tag,"
         + "player_character.id AS \"player_character.id\", "
+        + "player_character.region AS \"player_character.region\", "
         + "player_character.battlenet_id AS \"player_character.battlenet_id\", player_character.realm, player_character.name, "
         + "team_member.terran_games_played, team_member.protoss_games_played, "
         + "team_member.zerg_games_played, team_member.random_games_played "
@@ -188,11 +191,12 @@ public class LadderSearchDAO
     private static final String FIND_CARACTER_TEAM_MEMBERS_QUERY =
         "SELECT "
         + "season.battlenet_id AS \"season.battlenet_id\", season.year, season.number, "
-        + "team.region, team.league_type, team.queue_type, team.team_type, "
+        + "team.region AS \"team.region\", team.league_type, team.queue_type, team.team_type, "
         + "team.tier_type, "
         + "team.id AS \"team.id\", team.rating, team.wins, team.losses, "
         + "account.id AS \"account.id\", account.battle_tag,"
         + "player_character.id AS \"player_character.id\", "
+        + "player_character.region AS \"player_character.region\", "
         + "player_character.battlenet_id AS \"player_character.battlenet_id\", "
         + "player_character.realm, player_character.name, "
         + "team_member.terran_games_played, team_member.protoss_games_played, "
@@ -218,10 +222,9 @@ public class LadderSearchDAO
     private static final String FIND_DISTINCT_CHARACTER_QUERY =
         "SELECT "
         + "MAX(account.id) AS \"account.id\", "
-        + "MAX(account.battlenet_id) AS \"account.battlenet_id\", "
-        + "MAX(account.region) AS \"account.region\", "
         + "MAX(account.battle_tag) AS \"account.battle_tag\", "
         + "player_character_stats.player_character_id, "
+        + "MAX(player_character.region) AS \"player_character.region\", "
         + "MAX(player_character.battlenet_id) AS \"player_character.battlenet_id\", "
         + "MAX(player_character.realm) AS \"player_character.realm\", "
         + "MAX(player_character.name) AS \"player_character.name\", "
@@ -320,7 +323,6 @@ public class LadderSearchDAO
         Race race = rs.wasNull() ? null : conversionService.convert(raceInt, Race.class);
         return new LadderDistinctCharacter
         (
-            conversionService.convert(rs.getInt("account.region"), Region.class),
             conversionService.convert(rs.getInt("league_max"), League.LeagueType.class),
             rs.getInt("rating_max"),
             rs.getString("account.battle_tag"),
@@ -328,6 +330,7 @@ public class LadderSearchDAO
             (
                 rs.getLong("player_character_id"),
                 rs.getLong("account.id"),
+                conversionService.convert(rs.getInt("player_character.region"), Region.class),
                 rs.getLong("player_character.battlenet_id"),
                 rs.getInt("player_character.realm"),
                 rs.getString("player_character.name")
@@ -476,7 +479,7 @@ public class LadderSearchDAO
                 (
                     teamId,
                     season,
-                    conversionService.convert(rs.getInt("region"), Region.class),
+                    conversionService.convert(rs.getInt("team.region"), Region.class),
                     new BaseLeague
                     (
                         conversionService.convert(rs.getInt("league_type"), League.LeagueType.class),
@@ -500,6 +503,7 @@ public class LadderSearchDAO
                 (
                     rs.getLong("player_character.id"),
                     rs.getLong("account.id"),
+                    conversionService.convert(rs.getInt("player_character.region"), Region.class),
                     rs.getLong("player_character.battlenet_id"),
                     rs.getInt("realm"),
                     rs.getString("name")

--- a/src/main/java/com/nephest/battlenet/sc2/web/service/StatsService.java
+++ b/src/main/java/com/nephest/battlenet/sc2/web/service/StatsService.java
@@ -378,10 +378,10 @@ public class StatsService
             //blizzard can send invalid member without account sometimes. Ignoring these entries
             if (bMember.getAccount() == null) continue;
 
-            Account account = Account.of(season.getRegion(), bMember.getAccount());
+            Account account = Account.of(bMember.getAccount());
             accountDao.merge(account);
 
-            PlayerCharacter character = PlayerCharacter.of(account, bMember.getCharacter());
+            PlayerCharacter character = PlayerCharacter.of(account, season.getRegion(), bMember.getCharacter());
             playerCharacterDao.merge(character);
 
             TeamMember member = TeamMember.of(team, character, bMember.getRaces());

--- a/src/main/js/sc2-restful.js
+++ b/src/main/js/sc2-restful.js
@@ -465,7 +465,7 @@ function createMemberInfo(team, member)
     playerLink.setAttribute("data-character-id", member.character.id);
     playerLink.setAttribute("data-character-battlenet-id", member.character.battlenetId);
     playerLink.setAttribute("data-character-realm", member.character.realm);
-    playerLink.setAttribute("data-character-region",  team.region);
+    playerLink.setAttribute("data-character-region",  member.character.region);
     playerLink.setAttribute("data-character-battletag", member.account.battleTag);
     playerLink.addEventListener("click", showCharacterInfo);
     playerLink.appendChild(racesElem);
@@ -619,7 +619,7 @@ function updateCharacters(searchResult)
     {
         const character = searchResult[i];
         const row = tbody.insertRow();
-        row.insertCell().appendChild(createImage("flag/", character.region.toLowerCase(), ["table-image-long"]));
+        row.insertCell().appendChild(createImage("flag/", character.members.character.region.toLowerCase(), ["table-image-long"]));
         row.insertCell().appendChild(createImage("league/", enumOfId(character.leagueMax, LEAGUE).name, ["table-image", "table-image-square", "mr-1"]));
         row.insertCell().appendChild(document.createTextNode(character.ratingMax));
         row.insertCell().appendChild(document.createTextNode(character.totalGamesPlayed))

--- a/src/main/resources/schema-postgres.sql
+++ b/src/main/resources/schema-postgres.sql
@@ -22,19 +22,16 @@ CREATE TABLE "account"
 (
 
     "id" BIGSERIAL,
-    "region" SMALLINT NOT NULL,
-    "battlenet_id" BIGINT NOT NULL,
     "battle_tag" VARCHAR(30) NOT NULL,
     "updated" TIMESTAMP NOT NULL,
 
     PRIMARY KEY ("id"),
 
-    CONSTRAINT "uq_account_region_battlenet_id"
-        UNIQUE ("region", "battlenet_id")
+    CONSTRAINT "uq_account_battle_tag"
+        UNIQUE ("battle_tag")
 
 );
 
-CREATE INDEX "ix_account_battle_tag" ON "account"("battle_tag");
 CREATE INDEX "ix_account_updated" ON "account"("updated");
 
 CREATE TABLE "player_character"
@@ -43,6 +40,7 @@ CREATE TABLE "player_character"
     "id" BIGSERIAL,
     "account_id" BIGINT NOT NULL,
     "battlenet_id" BIGINT NOT NULL,
+    "region" SMALLINT NOT NULL,
     "realm" SMALLINT NOT NULL,
     "name" VARCHAR(30) NOT NULL,
 
@@ -53,8 +51,8 @@ CREATE TABLE "player_character"
         REFERENCES "account"("id")
         ON DELETE CASCADE ON UPDATE CASCADE,
 
-    CONSTRAINT "uq_player_character_account_id_battlenet_id"
-        UNIQUE ("account_id", "battlenet_id")
+    CONSTRAINT "uq_player_character_region_battlenet_id"
+        UNIQUE ("region", "battlenet_id")
 
 );
 

--- a/src/main/sql/1.0.0-1.1.0-migration.sql
+++ b/src/main/sql/1.0.0-1.1.0-migration.sql
@@ -27,3 +27,47 @@ CREATE TABLE "player_character_stats"
 
 CREATE UNIQUE INDEX "uq_player_character_stats_main"
     ON "player_character_stats"("player_character_id", COALESCE("season_id", -32768), COALESCE("race", -32768), "queue_type", "team_type");
+
+ALTER TABLE "player_character" ADD COLUMN "region" SMALLINT,
+DROP CONSTRAINT "uq_player_character_account_id_battlenet_id";
+
+UPDATE "player_character" SET "region"="account"."region"
+FROM "account" WHERE "player_character"."account_id"="account"."id";
+
+ALTER TABLE "player_character" ALTER COLUMN "region" SET NOT NULL,
+ADD CONSTRAINT "uq_player_character_region_battlenet_id"
+UNIQUE ("region", "battlenet_id");
+
+ALTER TABLE "player_character"
+ADD COLUMN "battle_tag" VARCHAR(30),
+DROP CONSTRAINT "fk_player_character_account_id";
+
+UPDATE "player_character" SET "battle_tag"="account"."battle_tag"
+FROM "account" WHERE "player_character"."account_id"="account"."id";
+
+DELETE FROM "account"
+USING
+(
+   SELECT "battle_tag", MIN("id") AS min_id
+   FROM "account"
+   GROUP BY "battle_tag"
+) sub
+WHERE "account"."battle_tag"=sub."battle_tag"
+AND "account"."id" != sub.min_id;
+
+UPDATE "player_character" SET "account_id"="account"."id"
+FROM "account" WHERE "player_character"."battle_tag"="account"."battle_tag";
+
+ALTER TABLE "player_character"
+DROP COLUMN "battle_tag",
+ADD CONSTRAINT "fk_player_character_account_id"
+    FOREIGN KEY ("account_id")
+    REFERENCES "account"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+DROP INDEX "ix_account_battle_tag";
+ALTER TABLE "account"
+DROP CONSTRAINT "uq_account_region_battlenet_id",
+DROP COLUMN "region",
+DROP COLUMN "battlenet_id";
+ALTER TABLE "account" ADD CONSTRAINT "uq_account_battle_tag" UNIQUE("battle_tag");

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/AccountTest.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/AccountTest.java
@@ -23,22 +23,18 @@ package com.nephest.battlenet.sc2.model.local;
 import com.nephest.battlenet.sc2.util.TestUtil;
 import org.junit.jupiter.api.Test;
 
-import static com.nephest.battlenet.sc2.model.Region.EU;
-import static com.nephest.battlenet.sc2.model.Region.US;
-
 public class AccountTest
 {
 
     @Test
     public void testUniqueness()
     {
-        Account account = new Account(0l, EU, 0l, "Name#123");
-        Account equalsAccount = new Account(1l, EU, 0l, "DiffName#321");
+        Account account = new Account(0L, "Name#123");
+        Account equalsAccount = new Account(1L, "Name#123");
 
         Account[] notEqualAccounts = new Account[]
         {
-            new Account(0l, US, 0l, "Name#123"),
-            new Account(0l, EU, 1l, "Name#123")
+            new Account(0L, "DiffName#123")
         };
 
         TestUtil.testUniqueness(account, equalsAccount, notEqualAccounts);

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/PlayerCharacterTest.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/PlayerCharacterTest.java
@@ -20,6 +20,7 @@
  */
 package com.nephest.battlenet.sc2.model.local;
 
+import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.util.TestUtil;
 import org.junit.jupiter.api.Test;
 
@@ -29,13 +30,13 @@ public class PlayerCharacterTest
     @Test
     public void testUniqueness()
     {
-        PlayerCharacter character = new PlayerCharacter(0l, 0l, 0l, 0, "Name");
-        PlayerCharacter equalsCharacter = new PlayerCharacter(1l, 0l, 0l, 1, "DiffName");
+        PlayerCharacter character = new PlayerCharacter(0L, 0L, Region.EU, 0L, 0, "Name");
+        PlayerCharacter equalsCharacter = new PlayerCharacter(1L, 1L, Region.EU, 0L, 1, "DiffName");
 
         PlayerCharacter[] notEqualCharacters = new PlayerCharacter[]
         {
-            new PlayerCharacter(0l, 1l, 0l, 0, "Name"),
-            new PlayerCharacter(0l, 0l, 1l, 0, "Name")
+            new PlayerCharacter(0L, 0L, Region.US, 0L, 0, "Name"),
+            new PlayerCharacter(0L, 0L, Region.EU, 1L, 0, "Name")
         };
 
         TestUtil.testUniqueness(character, equalsCharacter, notEqualCharacters);

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/SeasonGenerator.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/SeasonGenerator.java
@@ -138,8 +138,9 @@ public class SeasonGenerator
             for(int memberIx = 0; memberIx < queueType.getTeamFormat().getMemberCount(teamType); memberIx++)
             {
                 int accId = Integer.parseInt(teamCount + "" + memberIx);
-                Account account = accountDAO.create(new Account(null, season.getRegion(), (long) accId, "battletag#" + (long) accId));
-                PlayerCharacter character = playerCharacterDAO.create(new PlayerCharacter(null, account.getId(), (long) accId, DEFAULT_REALM, "character#" + (long) accId));
+                Account account = accountDAO.create(new Account(null, "battletag#" + (long) accId));
+                PlayerCharacter character = playerCharacterDAO
+                    .create(new PlayerCharacter(null, account.getId(),season.getRegion(), (long) accId, DEFAULT_REALM, "character#" + (long) accId));
                 teamMemberDAO.create(new TeamMember(team.getId(), character.getId(), 1, 2, 3, 4));
             }
             teamCount++;

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterStatsDAOIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterStatsDAOIT.java
@@ -95,8 +95,9 @@ public class PlayerCharacterStatsDAOIT
         Division gold2 = divisionDAO.findListByLadder(season2.getBattlenetId(), region, BaseLeague.LeagueType.GOLD, QUEUE_TYPE, TEAM_TYPE, TIER_TYPE).get(0);
 
         //create ref data that actually matters
-        Account acc = accountDAO.create(new Account(null, region, 9999L, "refaccount#123"));
-        PlayerCharacter character = playerCharacterDAO.create(new PlayerCharacter(null, acc.getId(), 9999L, 1, "refchar#123"));
+        Account acc = accountDAO.create(new Account(null, "refaccount#123"));
+        PlayerCharacter character = playerCharacterDAO
+            .create(new PlayerCharacter(null, acc.getId(), region, 9999L, 1, "refchar#123"));
         createTeam(season1, Race.TERRAN, region, BaseLeague.LeagueType.BRONZE, QUEUE_TYPE, TEAM_TYPE, TIER_TYPE, bronze1, BigInteger.valueOf(9999L), 1L, character);
         createTeam(season1, Race.PROTOSS, region, BaseLeague.LeagueType.BRONZE, QUEUE_TYPE, TEAM_TYPE, TIER_TYPE, bronze1, BigInteger.valueOf(10000L), 1L, character);
         createTeam(season1, Race.ZERG, region, BaseLeague.LeagueType.BRONZE, QUEUE_TYPE, TEAM_TYPE, TIER_TYPE, bronze1, BigInteger.valueOf(10001L), 1L, character);

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/SqlSyntaxIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/SqlSyntaxIT.java
@@ -120,13 +120,14 @@ public class SqlSyntaxIT
         assertEquals(2, team.getTies());
         assertEquals(2, team.getPoints());
 
-        accountDAO.create(new Account(null, season.getRegion(), 1L, "tag#1"));
-        Account account = accountDAO.merge(new Account(null, season.getRegion(), 1L, "newtag#2"));
+        accountDAO.create(new Account(null, "tag#1"));
+        Account account = accountDAO.merge(new Account(null, "newtag#2"));
         assertEquals("newtag#2", account.getBattleTag());
         accountDAO.removeExpiredByPrivacy();
 
-        playerCharacterDAO.create(new PlayerCharacter(null, account.getId(), 1L, 1, "name#1"));
-        PlayerCharacter character = playerCharacterDAO.merge(new PlayerCharacter(null, account.getId(), 1L, 2, "newname#2"));
+        playerCharacterDAO.create(new PlayerCharacter(null, account.getId(), season.getRegion(), 1L, 1, "name#1"));
+        PlayerCharacter character = playerCharacterDAO
+            .merge(new PlayerCharacter(null, account.getId(), season.getRegion(), 1L, 2, "newname#2"));
         assertEquals(2, character.getRealm());
         assertEquals("newname#2", character.getName());
 


### PR DESCRIPTION
Fixes #8 
Account battlenet_id assumed to be unique in the upstream API. It is not the case, the API returns the id of a character
rather than an account. There is no way to get the account id for the API, so removing it completely, making account cross
regional entity. Region info is moved to the player_character relation.