### PR TITLE
don't force web retry

### DIFF
--- a/src/main/java/com/nephest/battlenet/sc2/web/service/BlizzardSC2API.java
+++ b/src/main/java/com/nephest/battlenet/sc2/web/service/BlizzardSC2API.java
@@ -1477,8 +1477,7 @@ extends BaseAPI
             .map(APIHealthMonitor::getRequests)
             .anyMatch(l->l > 0)
                 ? getPlayerCharacters(region, profileId, true)
-                : getPlayerCharacters(region, profileId, false)
-                    .onErrorResume(e->getPlayerCharacters(region, profileId, true));
+                : getPlayerCharacters(region, profileId, false);
     }
 
     public Flux<Patch> getPatches(Region region, Long minId, Long maxId, int limit)


### PR DESCRIPTION
The web API is no longer active. Don't force a web retry if there is no indication that it's used by the service.