### PR TITLE
remove report evidence from notification

### DIFF
--- a/src/main/java/com/nephest/battlenet/sc2/web/service/PlayerCharacterReportService.java
+++ b/src/main/java/com/nephest/battlenet/sc2/web/service/PlayerCharacterReportService.java
@@ -184,11 +184,10 @@ public class PlayerCharacterReportService
                     String.format(characterUrlTemplate, accusedPlayer2.getId())))
                 .append("\n");
         }
-        sb.append("**Accusations:** ").append(report.getType()).append("\n");
-        sb.append("**Evidence:** ")
-            .append(evidence.getDescription()).append("\n\n");
-        sb.append("*You received this notification because you are a moderator, accused player, "
-            + "or original reporter*\n");
+        sb.append("**Accusations:** ").append(report.getType()).append("\n")
+            .append("\n")
+            .append("*You received this notification because you are a moderator, accused player, "
+                + "or original reporter*\n");
 
         return sb.toString();
     }

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterReportIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterReportIT.java
@@ -254,7 +254,6 @@ public class PlayerCharacterReportIT
             + "**Reporter:** BattleTag: refaccount#123\n"
             + "**Accused player:** [character#0](http://127.0.1.1:0/?type=character&id=1&m=1#player-stats-player)\n"
             + "**Accusations:** CHEATER\n"
-            + "**Evidence:** evidence text\n"
             + "\n"
             + "*You received this notification because you are a moderator, accused player, or original reporter*\n",
             account.getId(), //reporter
@@ -281,7 +280,6 @@ public class PlayerCharacterReportIT
             + "**Accused player:** [character#0](http://127.0.1.1:0/?type=character&id=1&m=1#player-stats-player)\n"
             + "**Accused player2:** [character#10](http://127.0.1.1:0/?type=character&id=2&m=1#player-stats-player)\n"
             + "**Accusations:** LINK\n"
-            + "**Evidence:** evidence text link\n"
             + "\n"
             + "*You received this notification because you are a moderator, accused player, or original reporter*\n",
             account.getId(), //reporter


### PR DESCRIPTION
This is a temporary solution until we have a filter and premoderation.

Closes #165 