### PR TITLE
reset Session.isHistorical flag asap

### DIFF
--- a/src/main/webapp/static/script/HistoryUtil.js
+++ b/src/main/webapp/static/script/HistoryUtil.js
@@ -317,6 +317,7 @@ class HistoryUtil
             HistoryUtil.updateActiveTabs();
             Session.statesRestored += 1;
             Util.setGeneratingStatus(STATUS.SUCCESS);
+            Session.isHistorical = false;
             if(scrollTo != null) Util.scrollIntoViewById(scrollTo);
             ElementUtil.executeActiveTabTask();
         });


### PR DESCRIPTION
closes #344 

There are some background tasks that are not a part of the task chain. Such tasks can delay reset of the isHistorical flag.

This change resets the flag ASAP. Background tasks should only do some simple things and don't affect the history flow. If such task affects the flow or relies on the flag, then it should be included in the main task chain.

This allows us to have background tasks that don't block the execution chain and preserve the isHistorical flag consistency at the same time.