### PR TITLE
call ReactorRateLimiter.requestSlot lazily

### DIFF
--- a/src/main/java/com/nephest/battlenet/sc2/web/service/AligulacAPI.java
+++ b/src/main/java/com/nephest/battlenet/sc2/web/service/AligulacAPI.java
@@ -70,7 +70,7 @@ extends BaseAPI
             .retrieve()
             .bodyToMono(AligulacProPlayerRoot.class)
             .retryWhen(rateLimiter.retryWhen(getRetry(WebServiceUtil.RETRY)))
-            .delaySubscription(rateLimiter.requestSlot());
+            .delaySubscription(Mono.defer(rateLimiter::requestSlot));
     }
 
 }

--- a/src/main/java/com/nephest/battlenet/sc2/web/service/BilibiliAPI.java
+++ b/src/main/java/com/nephest/battlenet/sc2/web/service/BilibiliAPI.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2023 Oleksandr Masniuk
+// Copyright (C) 2020-2025 Oleksandr Masniuk
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 package com.nephest.battlenet.sc2.web.service;
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 @Service
 public class BilibiliAPI
@@ -75,7 +76,7 @@ extends BaseAPI
             .map(BilibiliAPI::fix)
             .sort(COMPARATOR)
             .retryWhen(rateLimiter.retryWhen(getRetry(WebServiceUtil.RETRY)))
-            .delaySubscription(rateLimiter.requestSlot());
+            .delaySubscription(Mono.defer(rateLimiter::requestSlot));
     }
 
     private Flux<BilibiliStream> getStreamsRecursively

--- a/src/main/java/com/nephest/battlenet/sc2/web/service/BlizzardSC2API.java
+++ b/src/main/java/com/nephest/battlenet/sc2/web/service/BlizzardSC2API.java
@@ -790,7 +790,8 @@ extends BaseAPI
             .bodyToMono(BlizzardDataSeason.class).cast(BlizzardSeason.class)
             .retryWhen(ReactorRateLimiter.retryWhen(
                 regionalRateLimiters.get(region), getRetry(region, WebServiceUtil.RETRY, false)))
-            .delaySubscription(ReactorRateLimiter.requestSlot(regionalRateLimiters.get(region)))
+            .delaySubscription(Mono.defer(()->
+                ReactorRateLimiter.requestSlot(regionalRateLimiters.get(region))))
             .doOnRequest(s->healthMonitors.get(region).addRequest())
             .doOnError(t->healthMonitors.get(region).addError());
     }
@@ -806,7 +807,8 @@ extends BaseAPI
             .bodyToMono(BlizzardSeason.class)
             .retryWhen(ReactorRateLimiter.retryWhen(
                 regionalRateLimiters.get(region), getRetry(region, WebServiceUtil.RETRY, false)))
-            .delaySubscription(ReactorRateLimiter.requestSlot(regionalRateLimiters.get(region)))
+            .delaySubscription(Mono.defer(()->
+                ReactorRateLimiter.requestSlot(regionalRateLimiters.get(region))))
             .doOnRequest(s->healthMonitors.get(region).addRequest())
             .doOnError(t->healthMonitors.get(region).addError());
     }
@@ -868,7 +870,8 @@ extends BaseAPI
             .bodyToMono(BlizzardLeague.class)
             .retryWhen(ReactorRateLimiter.retryWhen(
                 regionalRateLimiters.get(region), getRetry(region, WebServiceUtil.RETRY, false)))
-            .delaySubscription(ReactorRateLimiter.requestSlot(regionalRateLimiters.get(region)))
+            .delaySubscription(Mono.defer(()->
+                ReactorRateLimiter.requestSlot(regionalRateLimiters.get(region))))
             .doOnRequest(s->healthMonitors.get(region).addRequest())
             .doOnError(t->healthMonitors.get(region).addError());
 
@@ -928,7 +931,8 @@ extends BaseAPI
             .bodyToMono(BlizzardLadder.class)
             .retryWhen(ReactorRateLimiter.retryWhen(
                 regionalRateLimiters.get(region), getRetry(region, WebServiceUtil.RETRY, false), priorityName))
-            .delaySubscription(ReactorRateLimiter.requestSlot(regionalRateLimiters.get(region), priorityName))
+            .delaySubscription(Mono.defer(()->
+                ReactorRateLimiter.requestSlot(regionalRateLimiters.get(region), priorityName)))
             .doOnRequest(s->healthMonitors.get(region).addRequest())
             .doOnError(t->healthMonitors.get(region).addError());
     }
@@ -959,7 +963,8 @@ extends BaseAPI
             .map(s->extractNewTeams(s, startingFromEpochSeconds))
             .retryWhen(ReactorRateLimiter.retryWhen(
                 regionalRateLimiters.get(region), getRetry(region, WebServiceUtil.RETRY, false), priorityName))
-            .delaySubscription(ReactorRateLimiter.requestSlot(regionalRateLimiters.get(region), priorityName))
+            .delaySubscription(Mono.defer(()->
+                ReactorRateLimiter.requestSlot(regionalRateLimiters.get(region), priorityName)))
             .doOnRequest(s->healthMonitors.get(region).addRequest())
             .doOnError(t->healthMonitors.get(region).addError());
     }
@@ -1116,7 +1121,8 @@ extends BaseAPI
                 }
             })
             .retryWhen(ReactorRateLimiter.retryWhen(context.getRateLimiters(), retry))
-            .delaySubscription(ReactorRateLimiter.requestSlot(context.getRateLimiters()))
+            .delaySubscription(Mono.defer(()->
+                ReactorRateLimiter.requestSlot(context.getRateLimiters())))
             .doOnRequest(s->context.getHealthMonitor().addRequest())
             .doOnError(t->context.getHealthMonitor().addError());
     }
@@ -1255,7 +1261,8 @@ extends BaseAPI
             })
             .retryWhen(ReactorRateLimiter.retryWhen(
                 context.getRateLimiters(), getRetry(region, WebServiceUtil.RETRY_SKIP_NOT_FOUND, web), priorityName))
-            .delaySubscription(ReactorRateLimiter.requestSlot(context.getRateLimiters(), priorityName))
+            .delaySubscription(Mono.defer(()->
+                ReactorRateLimiter.requestSlot(context.getRateLimiters(), priorityName)))
             .doOnRequest(s->context.getHealthMonitor().addRequest())
             .doOnError(t->context.getHealthMonitor().addError());
     }
@@ -1370,7 +1377,8 @@ extends BaseAPI
             .zipWith(Mono.just(playerCharacter))
             .retryWhen(ReactorRateLimiter.retryWhen(
                 context.getRateLimiters(), getMatchRetry(region, web), priorityName))
-            .delaySubscription(ReactorRateLimiter.requestSlot(context.getRateLimiters(), priorityName))
+            .delaySubscription(Mono.defer(()->
+                ReactorRateLimiter.requestSlot(context.getRateLimiters(), priorityName)))
             .doOnRequest(s->{
                 matchHealthMonitors.get(region).addRequest();
                 context.getHealthMonitor().addRequest();
@@ -1434,7 +1442,8 @@ extends BaseAPI
             .zipWith(Mono.just(playerCharacter))
             .retryWhen(ReactorRateLimiter.retryWhen(
                 context.getRateLimiters(), getRetry(region, WebServiceUtil.RETRY_NEVER, web)))
-            .delaySubscription(ReactorRateLimiter.requestSlot(context.getRateLimiters()))
+            .delaySubscription(Mono.defer(()->
+                ReactorRateLimiter.requestSlot(context.getRateLimiters())))
             .doOnRequest(s->context.getHealthMonitor().addRequest())
             .doOnError(t->context.getHealthMonitor().addError());
     }
@@ -1468,7 +1477,8 @@ extends BaseAPI
             .zipWith(Mono.just(playerCharacter))
             .retryWhen(ReactorRateLimiter.retryWhen(
                 context.getRateLimiters(), getRetry(region, WebServiceUtil.RETRY_NEVER, web)))
-            .delaySubscription(ReactorRateLimiter.requestSlot(context.getRateLimiters()))
+            .delaySubscription(Mono.defer(()->
+                ReactorRateLimiter.requestSlot(context.getRateLimiters())))
             .doOnRequest(s->context.getHealthMonitor().addRequest())
             .doOnError(t->context.getHealthMonitor().addError());
     }
@@ -1507,11 +1517,10 @@ extends BaseAPI
                 getRetry(region, WebServiceUtil.RETRY_ONCE, web),
                 SYSTEM_REQUEST_LIMIT_PRIORITY_NAME
             ))
-            .delaySubscription(ReactorRateLimiter.requestSlot
-            (
+            .delaySubscription(Mono.defer(()->ReactorRateLimiter.requestSlot(
                 context.getRateLimiters(),
                 SYSTEM_REQUEST_LIMIT_PRIORITY_NAME
-            ))
+            )))
             .doOnRequest(s->context.getHealthMonitor().addRequest())
             .doOnError(t->context.getHealthMonitor().addError());
     }
@@ -1562,8 +1571,9 @@ extends BaseAPI
                 context.getRateLimiters(),
                 getRetry(region, WebServiceUtil.RETRY, true),
                 SYSTEM_REQUEST_LIMIT_PRIORITY_NAME))
-            .delaySubscription(ReactorRateLimiter.requestSlot(context.getRateLimiters(),
-                SYSTEM_REQUEST_LIMIT_PRIORITY_NAME))
+            .delaySubscription(Mono.defer(()->ReactorRateLimiter.requestSlot(
+                context.getRateLimiters(),
+                SYSTEM_REQUEST_LIMIT_PRIORITY_NAME)))
             .doOnRequest(s->context.getHealthMonitor().addRequest())
             .doOnError(t->context.getHealthMonitor().addError());
     }

--- a/src/main/java/com/nephest/battlenet/sc2/web/service/DiscordAPI.java
+++ b/src/main/java/com/nephest/battlenet/sc2/web/service/DiscordAPI.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2023 Oleksandr Masniuk
+// Copyright (C) 2020-2025 Oleksandr Masniuk
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 package com.nephest.battlenet.sc2.web.service;
@@ -163,7 +163,7 @@ extends BaseAPI
                 .retryWhen(rateLimiter.retryWhen(RETRY_WHEN_TOO_MANY_REQUESTS))
         )
             .next()
-            .delaySubscription(rateLimiter.requestSlot());
+            .delaySubscription(Mono.defer(rateLimiter::requestSlot));
     }
 
     private <T> Flux<T> getFlux(Class<T> clazz, String uri, Object... params)
@@ -178,7 +178,7 @@ extends BaseAPI
                 .exchangeToFlux(resp->readRequestRateAndExchangeToFlux(resp, clazz))
                 .retryWhen(rateLimiter.retryWhen(RETRY_WHEN_TOO_MANY_REQUESTS))
         )
-            .delaySubscription(rateLimiter.requestSlot());
+            .delaySubscription(Mono.defer(rateLimiter::requestSlot));
     }
 
     public Mono<DiscordUser> getCurrentUser()
@@ -191,7 +191,7 @@ extends BaseAPI
         return discordClient.getClient()
             .getUserById(id)
             .map(DiscordUser::from)
-            .delaySubscription(rateLimiter.requestSlot());
+            .delaySubscription(Mono.defer(rateLimiter::requestSlot));
     }
 
     public Flux<DiscordUser> getUsers(Iterable<? extends Snowflake> ids)
@@ -203,7 +203,7 @@ extends BaseAPI
     public Flux<DiscordConnection> getCurrentUserConnections()
     {
         return getFlux(DiscordConnection.class, "/users/@me/connections")
-            .delaySubscription(rateLimiter.requestSlot());
+            .delaySubscription(Mono.defer(rateLimiter::requestSlot));
     }
 
     /**
@@ -237,7 +237,7 @@ extends BaseAPI
                 .retryWhen(rateLimiter.retryWhen(RETRY_WHEN_TOO_MANY_REQUESTS))
         )
             .next()
-            .delaySubscription(rateLimiter.requestSlot());
+            .delaySubscription(Mono.defer(rateLimiter::requestSlot));
     }
 
     public Mono<Void> updateConnectionMetaData
@@ -262,7 +262,7 @@ extends BaseAPI
                 .retryWhen(rateLimiter.retryWhen(RETRY_WHEN_TOO_MANY_REQUESTS))
         )
             .next()
-            .delaySubscription(rateLimiter.requestSlot());
+            .delaySubscription(Mono.defer(rateLimiter::requestSlot));
     }
 
     @Cacheable(cacheNames = "discord-bot-guilds")
@@ -299,7 +299,7 @@ extends BaseAPI
                 .exchangeToFlux(resp->readRequestRateAndExchangeToFlux(resp, clazz))
                 .retryWhen(rateLimiter.retryWhen(RETRY_WHEN_TOO_MANY_REQUESTS))
         )
-            .delaySubscription(rateLimiter.requestSlot());
+            .delaySubscription(Mono.defer(rateLimiter::requestSlot));
     }
 
     public Flux<Void> revokeRefreshToken(OAuth2AuthorizedClient oAuth2AuthorizedClient)
@@ -322,7 +322,7 @@ extends BaseAPI
                 .exchangeToMono(resp->readRequestRateAndExchangeToMono(resp, Void.class))
                 .retryWhen(rateLimiter.retryWhen(RETRY_WHEN_TOO_MANY_REQUESTS))
         )
-            .delaySubscription(rateLimiter.requestSlot());
+            .delaySubscription(Mono.defer(rateLimiter::requestSlot));
     }
 
     public Optional<OAuth2AuthorizedClient> getAuthorizedClient(Long accountId)
@@ -335,7 +335,7 @@ extends BaseAPI
     public <T> Flux<T> withLimiter(Publisher<T> publisher, boolean localLimiter)
     {
         Flux<T> result =  discordClient.getGlobalRateLimiter().withLimiter(publisher);
-        if(localLimiter) result = result.delaySubscription(rateLimiter.requestSlot());
+        if(localLimiter) result = result.delaySubscription(Mono.defer(rateLimiter::requestSlot));
         return result;
     }
 

--- a/src/main/java/com/nephest/battlenet/sc2/web/service/SC2ArcadeAPI.java
+++ b/src/main/java/com/nephest/battlenet/sc2/web/service/SC2ArcadeAPI.java
@@ -105,7 +105,7 @@ extends BaseAPI
             .accept(APPLICATION_JSON)
             .exchangeToMono(resp->readRequestRateAndExchangeToMono(resp, ArcadePlayerCharacter.class))
             .retryWhen(rateLimiter.retryWhen(getRetry(WebServiceUtil.RETRY)))
-            .delaySubscription(rateLimiter.requestSlot());
+            .delaySubscription(Mono.defer(rateLimiter::requestSlot));
     }
 
     public Mono<ArcadePlayerCharacter> findByRegionAndGameId(Region region, String gameId)
@@ -128,7 +128,7 @@ extends BaseAPI
             .accept(APPLICATION_JSON)
             .exchangeToMono(resp->readRequestRateAndExchangeToMono(resp, ArcadePlayerCharacter.class))
             .retryWhen(rateLimiter.retryWhen(getRetry(WebServiceUtil.RETRY)))
-            .delaySubscription(rateLimiter.requestSlot());
+            .delaySubscription(Mono.defer(rateLimiter::requestSlot));
     }
 
 }

--- a/src/main/java/com/nephest/battlenet/sc2/web/service/SC2ReplayStatsAPI.java
+++ b/src/main/java/com/nephest/battlenet/sc2/web/service/SC2ReplayStatsAPI.java
@@ -77,7 +77,7 @@ extends BaseAPI
             .retrieve()
             .bodyToMono(ReplayStatsPlayerCharacter.class)
             .retryWhen(rateLimiter.retryWhen(getRetry(WebServiceUtil.RETRY)))
-            .delaySubscription(rateLimiter.requestSlot());
+            .delaySubscription(Mono.defer(rateLimiter::requestSlot));
     }
 
 }

--- a/src/main/java/com/nephest/battlenet/sc2/web/service/liquipedia/LiquipediaAPI.java
+++ b/src/main/java/com/nephest/battlenet/sc2/web/service/liquipedia/LiquipediaAPI.java
@@ -84,7 +84,7 @@ extends BaseAPI
             .accept(APPLICATION_JSON)
             .retrieve()
             .bodyToMono(LiquipediaMediaWikiRevisionQueryResult.class)
-            .delaySubscription(rateLimiter.requestSlot());
+            .delaySubscription(Mono.defer(rateLimiter::requestSlot));
     }
 
     public Flux<LiquipediaPlayer> parsePlayers(Set<String> names)

--- a/src/main/java/com/nephest/battlenet/sc2/web/util/ReactorRateLimiter.java
+++ b/src/main/java/com/nephest/battlenet/sc2/web/util/ReactorRateLimiter.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Oleksandr Masniuk
+// Copyright (C) 2020-2025 Oleksandr Masniuk
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 package com.nephest.battlenet.sc2.web.util;
@@ -25,7 +25,7 @@ import reactor.util.retry.RetrySpec;
 
     * Decorate target monos:
         * mono.retryWhen(rateLimiter.retryWhen(retrySpec));
-        * mono.delaySubscription(rateLimiter.requestSlot());
+        * mono.delaySubscription(Mono.defer(rateLimiter::requestSlot));
     * Refresh slots:
         * Flux
             .interval(Duration.ofSeconds(0), Duration.ofSeconds(1))


### PR DESCRIPTION
closes #353 

Not only the slot is only requested when subscribing to the publisher, but it also re-triggers it on followup subs.