### PR TITLE
Add DB lifecycle JUnit extension

### DIFF
--- a/src/test/java/com/nephest/battlenet/sc2/config/DatabaseTestConfig.java
+++ b/src/test/java/com/nephest/battlenet/sc2/config/DatabaseTestConfig.java
@@ -6,6 +6,7 @@ package com.nephest.battlenet.sc2.config;
 import com.nephest.battlenet.sc2.config.data.DataConfig;
 import com.nephest.battlenet.sc2.model.local.DBTestService;
 import com.nephest.battlenet.sc2.model.local.SeasonGenerator;
+import com.nephest.battlenet.sc2.model.util.TestDatabaseLifecycleService;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
@@ -25,7 +26,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
     {
         @ComponentScan.Filter(type = FilterType.ANNOTATION, value = Repository.class),
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = SeasonGenerator.class),
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = DBTestService.class)
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = DBTestService.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = TestDatabaseLifecycleService.class)
     }
 )
 @Import({CoreTestConfig.class, DataConfig.class, CommonBeanConfig.class})

--- a/src/test/java/com/nephest/battlenet/sc2/config/filter/HtmlUrlParameterRedirectFilterIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/config/filter/HtmlUrlParameterRedirectFilterIT.java
@@ -7,8 +7,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.local.SeasonGenerator;
@@ -16,17 +16,14 @@ import com.nephest.battlenet.sc2.model.local.dao.ClanDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderSearchDAO;
 import com.nephest.battlenet.sc2.model.navigation.Cursor;
 import com.nephest.battlenet.sc2.model.navigation.NavigationDirection;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -45,6 +42,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 @SpringBootTest(classes = AllTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class HtmlUrlParameterRedirectFilterIT
 {
 
@@ -57,21 +55,11 @@ public class HtmlUrlParameterRedirectFilterIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
-        @Autowired SeasonGenerator seasonGenerator,
-        @Autowired Client clickHouseClient
+        @Autowired SeasonGenerator seasonGenerator
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         seasonGenerator.generateDefaultSeason(1);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @ValueSource(strings = {"ladder", "following-ladder"})

--- a/src/test/java/com/nephest/battlenet/sc2/extension/AutoConfigureDatabase.java
+++ b/src/test/java/com/nephest/battlenet/sc2/extension/AutoConfigureDatabase.java
@@ -1,0 +1,26 @@
+// Copyright (C) 2020-2026 Oleksandr Masniuk
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.nephest.battlenet.sc2.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DatabaseLifecycleExtension.class)
+public @interface AutoConfigureDatabase
+{
+
+    enum ExecutionPhase
+    {
+        CLASS,
+        METHOD
+    }
+
+    ExecutionPhase value() default ExecutionPhase.METHOD;
+
+}

--- a/src/test/java/com/nephest/battlenet/sc2/extension/DatabaseLifecycleExtension.java
+++ b/src/test/java/com/nephest/battlenet/sc2/extension/DatabaseLifecycleExtension.java
@@ -1,0 +1,60 @@
+// Copyright (C) 2020-2026 Oleksandr Masniuk
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.nephest.battlenet.sc2.extension;
+
+import com.nephest.battlenet.sc2.model.util.TestDatabaseLifecycleService;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseLifecycleExtension
+implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback
+{
+
+    @Override
+    public void beforeAll(ExtensionContext context)
+    {
+        if(getPhase(context) == AutoConfigureDatabase.ExecutionPhase.CLASS)
+            getService(context).initDb();
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context)
+    {
+        if(getPhase(context) == AutoConfigureDatabase.ExecutionPhase.CLASS)
+            getService(context).clearDb();
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context)
+    {
+        if(getPhase(context) == AutoConfigureDatabase.ExecutionPhase.METHOD)
+            getService(context).initDb();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context)
+    {
+        if(getPhase(context) == AutoConfigureDatabase.ExecutionPhase.METHOD)
+            getService(context).clearDb();
+    }
+
+    private AutoConfigureDatabase.ExecutionPhase getPhase(ExtensionContext context)
+    {
+        return context.getTestClass()
+            .map(c -> c.getAnnotation(AutoConfigureDatabase.class))
+            .map(AutoConfigureDatabase::value)
+            .orElse(null);
+    }
+
+    private TestDatabaseLifecycleService getService(ExtensionContext context)
+    {
+        return SpringExtension.getApplicationContext(context)
+            .getBean(TestDatabaseLifecycleService.class);
+    }
+
+}

--- a/src/test/java/com/nephest/battlenet/sc2/model/PostgreSQLFunctionIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/PostgreSQLFunctionIT.java
@@ -5,12 +5,8 @@ package com.nephest.battlenet.sc2.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +19,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class PostgreSQLFunctionIT
 {
 
@@ -31,20 +28,6 @@ public class PostgreSQLFunctionIT
 
     @Autowired @Qualifier("sc2StatsConversionService")
     private ConversionService conversionService;
-
-    @BeforeAll
-    public static void beforeAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @CsvSource
     ({

--- a/src/test/java/com/nephest/battlenet/sc2/model/dao/StandardAPIReadonlyIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/dao/StandardAPIReadonlyIT.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2025 Oleksandr Masniuk
+// Copyright (C) 2020-2026 Oleksandr Masniuk
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 package com.nephest.battlenet.sc2.model.dao;
@@ -9,10 +9,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.Partition;
@@ -27,7 +27,6 @@ import com.nephest.battlenet.sc2.model.local.dao.PopulationStateDAO;
 import com.nephest.battlenet.sc2.model.local.dao.TeamDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderDistinctCharacter;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderSearchIndependentIT;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.web.controller.CharacterController;
 import com.nephest.battlenet.sc2.web.service.StatsService;
 import com.nephest.battlenet.sc2.web.service.WebServiceTestUtil;
@@ -37,7 +36,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
-import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,6 +48,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(classes = AllTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class StandardAPIReadonlyIT
 {
 
@@ -64,19 +63,15 @@ public class StandardAPIReadonlyIT
     @BeforeAll
     public static void init
     (
-        @Autowired DataSource dataSource,
         @Autowired WebApplicationContext webApplicationContext,
         @Autowired SeasonGenerator generator,
         @Autowired TeamDAO teamDAO,
         @Autowired LeagueStatsDAO leagueStatsDAO,
         @Autowired PopulationStateDAO populationStateDAO,
-        @Autowired PlayerCharacterStatsDAO playerCharacterStatsDAO,
-        @Autowired Client clickHouseClient
+        @Autowired PlayerCharacterStatsDAO playerCharacterStatsDAO
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-
         generator.generateDefaultSeason
         (
             List.of(Region.values()),

--- a/src/test/java/com/nephest/battlenet/sc2/model/dao/StandardDataReadonlyIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/dao/StandardDataReadonlyIT.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2025 Oleksandr Masniuk
+// Copyright (C) 2020-2026 Oleksandr Masniuk
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 package com.nephest.battlenet.sc2.model.dao;
@@ -7,8 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -31,7 +31,6 @@ import com.nephest.battlenet.sc2.model.local.dao.TeamDAO;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyId;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyIdEntry;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderTeamStateDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.time.OffsetDateTime;
 import java.util.Comparator;
@@ -39,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -56,6 +54,7 @@ import reactor.util.function.Tuple3;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class StandardDataReadonlyIT
 {
 
@@ -88,16 +87,12 @@ public class StandardDataReadonlyIT
     @BeforeAll
     public static void init
     (
-        @Autowired DataSource dataSource,
         @Autowired SeasonGenerator generator,
         @Autowired LeagueStatsDAO leagueStatsDAO,
-        @Autowired PopulationStateDAO populationStateDAO,
-        @Autowired Client clickHouseClient
+        @Autowired PopulationStateDAO populationStateDAO
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-
         generator.generateDefaultSeason
         (
             List.of(Region.values()),

--- a/src/test/java/com/nephest/battlenet/sc2/model/discord/dao/DiscordCursorSearchIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/discord/dao/DiscordCursorSearchIT.java
@@ -6,16 +6,13 @@ package com.nephest.battlenet.sc2.model.discord.dao;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.discord.DiscordUser;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.web.service.DiscordIT;
 import discord4j.common.util.Snowflake;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +21,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class DiscordCursorSearchIT
 {
 
@@ -33,26 +31,15 @@ public class DiscordCursorSearchIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
-        @Autowired DiscordUserDAO discordUserDAO,
-        @Autowired Client clickHouseClient
+        @Autowired DiscordUserDAO discordUserDAO
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         discordUserDAO.merge(Set.of(
             new DiscordUser(Snowflake.of(1L), "name1", 1),
             new DiscordUser(Snowflake.of(2L), "name2", 2),
             new DiscordUser(Snowflake.of(3L), "name3", 3)
         ));
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/TimerVarIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/TimerVarIT.java
@@ -5,14 +5,10 @@ package com.nephest.battlenet.sc2.model.local;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.local.dao.VarDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import java.time.Duration;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
@@ -20,25 +16,12 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class TimerVarIT
 {
 
     @Autowired
     private VarDAO varDAO;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testDurationBetweenRunsPersistence()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/AccountIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/AccountIT.java
@@ -8,21 +8,17 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.local.Account;
 import com.nephest.battlenet.sc2.model.local.DBTestService;
 import com.nephest.battlenet.sc2.model.local.PlayerCharacter;
 import com.nephest.battlenet.sc2.model.local.inner.AccountCharacterData;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.time.OffsetDateTime;
 import java.util.Set;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -34,6 +30,7 @@ import org.springframework.test.jdbc.JdbcTestUtils;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class AccountIT
 {
 
@@ -48,20 +45,6 @@ public class AccountIT
 
     @Autowired
     private JdbcTemplate template;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterEach
-    public void afterEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void whenAccountExists_thenReturnIt()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/AccountPropertyIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/AccountPropertyIT.java
@@ -5,17 +5,13 @@ package com.nephest.battlenet.sc2.model.local.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.local.Account;
 import com.nephest.battlenet.sc2.model.local.AccountProperty;
 import com.nephest.battlenet.sc2.model.local.SeasonGenerator;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import java.util.Set;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
@@ -23,6 +19,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class AccountPropertyIT
 {
 
@@ -31,20 +28,6 @@ public class AccountPropertyIT
 
     @Autowired
     private AccountPropertyDAO accountPropertyDAO;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testChain()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/ClanIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/ClanIT.java
@@ -11,10 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -29,7 +29,6 @@ import com.nephest.battlenet.sc2.model.local.SeasonGenerator;
 import com.nephest.battlenet.sc2.model.local.inner.ClanMemberEventData;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderClanMemberEvents;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderDistinctCharacter;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.model.validation.CursorNavigableResult;
 import com.nephest.battlenet.sc2.web.service.ClanService;
@@ -43,10 +42,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -59,6 +55,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = AllTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class ClanIT
 {
 
@@ -88,20 +85,6 @@ public class ClanIT
 
     @Autowired
     private MockMvc mvc;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterEach
-    public void afterEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testStatsCalculation()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/ClanMemberIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/ClanMemberIT.java
@@ -8,24 +8,20 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.local.Account;
 import com.nephest.battlenet.sc2.model.local.Clan;
 import com.nephest.battlenet.sc2.model.local.ClanMember;
 import com.nephest.battlenet.sc2.model.local.PlayerCharacter;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.time.OffsetDateTime;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -34,6 +30,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class ClanMemberIT
 {
 
@@ -51,20 +48,6 @@ public class ClanMemberIT
 
     @Autowired
     private JdbcTemplate template;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterEach
-    public void afterEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testMerge()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/ClanSearchIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/ClanSearchIT.java
@@ -10,16 +10,15 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.SortingOrder;
 import com.nephest.battlenet.sc2.model.local.Clan;
 import com.nephest.battlenet.sc2.model.navigation.Cursor;
 import com.nephest.battlenet.sc2.model.navigation.NavigationDirection;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.validation.CursorNavigableResult;
 import com.nephest.battlenet.sc2.model.web.SortParameter;
 import com.nephest.battlenet.sc2.web.service.WebServiceTestUtil;
@@ -30,9 +29,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -50,6 +47,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(classes = AllTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class ClanSearchIT
 {
 
@@ -66,15 +64,12 @@ public class ClanSearchIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
         @Autowired WebApplicationContext webApplicationContext,
         @Autowired JdbcTemplate template,
-        @Autowired ClanDAO clanDAO,
-        @Autowired Client clickHouseClient
+        @Autowired ClanDAO clanDAO
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         Region[] regions = Region.values();
         clans = IntStream.range(0, CLAN_COUNT)
             .boxed()
@@ -99,13 +94,6 @@ public class ClanSearchIT
             .apply(springSecurity())
             .alwaysDo(print())
             .build();
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/FastTeamIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/FastTeamIT.java
@@ -7,8 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -17,21 +17,17 @@ import com.nephest.battlenet.sc2.model.TeamType;
 import com.nephest.battlenet.sc2.model.local.SeasonGenerator;
 import com.nephest.battlenet.sc2.model.local.Team;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyId;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.util.LinkedHashSet;
 import java.util.List;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class FastTeamIT
 {
 
@@ -40,28 +36,6 @@ public class FastTeamIT
 
     @Autowired
     private FastTeamDAO fastTeamDAO;
-
-    @BeforeEach
-    public void beforeEach
-    (
-        @Autowired @Qualifier("dataSource") DataSource dataSource,
-        @Autowired Client clickHouseClient
-    )
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll
-    (
-        @Autowired @Qualifier("dataSource") DataSource dataSource,
-        @Autowired Client clickHouseClient
-    )
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testLoad()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/LadderUpdateDAOIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/LadderUpdateDAOIT.java
@@ -5,13 +5,12 @@ package com.nephest.battlenet.sc2.model.local.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.QueueType;
 import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.local.LadderUpdate;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.sql.SQLException;
 import java.time.Duration;
@@ -19,20 +18,17 @@ import java.time.OffsetDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class LadderUpdateDAOIT
 {
 
@@ -42,34 +38,11 @@ public class LadderUpdateDAOIT
     @Autowired
     private JdbcTemplate template;
 
-    @BeforeAll
-    public static void beforeAll
-    (
-        @Autowired @Qualifier("dataSource") DataSource dataSource,
-        @Autowired LadderUpdateDAO ladderUpdateDAO,
-        @Autowired Client clickHouseClient
-    )
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
     @AfterEach
     public void afterEach()
     throws SQLException
     {
         template.update("DELETE FROM ladder_update");
-    }
-
-    @AfterAll
-    public static void afterAll
-    (
-        @Autowired @Qualifier("dataSource") DataSource dataSource,
-        @Autowired Client clickHouseClient
-    )
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/LeagueTierIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/LeagueTierIT.java
@@ -6,15 +6,11 @@ package com.nephest.battlenet.sc2.model.local.dao;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.local.LeagueTier;
 import com.nephest.battlenet.sc2.model.local.SeasonGenerator;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
@@ -22,6 +18,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class LeagueTierIT
 {
 
@@ -30,20 +27,6 @@ public class LeagueTierIT
 
     @Autowired
     private LeagueTierDAO leagueTierDAO;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testMergeNullTiers()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/MapStatsFilmSpecDAOIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/MapStatsFilmSpecDAOIT.java
@@ -9,20 +9,16 @@ import static com.nephest.battlenet.sc2.model.Race.TERRAN;
 import static com.nephest.battlenet.sc2.model.Race.ZERG;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.local.MapStatsFilmSpec;
 import com.nephest.battlenet.sc2.model.local.MatchUp;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -31,6 +27,7 @@ import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class MapStatsFilmSpecDAOIT
 {
 
@@ -39,20 +36,6 @@ public class MapStatsFilmSpecDAOIT
 
     @Autowired
     private JdbcTemplate template;
-
-    @BeforeAll
-    public static void beforeAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @AfterEach
     public void afterEach()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/MapStatsIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/MapStatsIT.java
@@ -10,9 +10,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.BaseMatch;
@@ -29,7 +29,6 @@ import com.nephest.battlenet.sc2.model.local.Season;
 import com.nephest.battlenet.sc2.model.local.SeasonGenerator;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderMapStats;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderMapStatsDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.web.service.WebServiceTestUtil;
 import java.time.OffsetDateTime;
@@ -42,8 +41,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,6 +58,7 @@ import reactor.util.function.Tuples;
 
 @SpringBootTest(classes = AllTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class MapStatsIT
 {
 
@@ -114,25 +112,15 @@ public class MapStatsIT
     @BeforeEach
     public void beforeAll
     (
-        @Autowired DataSource dataSource,
-        @Autowired WebApplicationContext webApplicationContext,
-        @Autowired Client clickHouseClient
+        @Autowired WebApplicationContext webApplicationContext
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         mvc = MockMvcBuilders
             .webAppContextSetup(webApplicationContext)
             .apply(springSecurity())
             .alwaysDo(print())
             .build();
-    }
-
-    @AfterEach
-    public void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/NotificationIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/NotificationIT.java
@@ -6,8 +6,8 @@ package com.nephest.battlenet.sc2.model.local.dao;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.local.Account;
 import com.nephest.battlenet.sc2.model.local.Notification;
@@ -15,9 +15,6 @@ import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -26,6 +23,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class NotificationIT
 {
 
@@ -37,20 +35,6 @@ public class NotificationIT
 
     @Autowired
     private JdbcTemplate template;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterEach
-    public void afterEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testLifecycleChain()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterDAOIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterDAOIT.java
@@ -10,9 +10,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
 import com.nephest.battlenet.sc2.config.security.SC2PulseAuthority;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.BasePlayerCharacter;
@@ -40,7 +40,6 @@ import com.nephest.battlenet.sc2.model.local.TeamMember;
 import com.nephest.battlenet.sc2.model.local.TeamState;
 import com.nephest.battlenet.sc2.model.local.inner.AccountCharacterData;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyId;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.web.service.BlizzardPrivacyService;
 import discord4j.common.util.Snowflake;
@@ -50,10 +49,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -62,6 +58,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class PlayerCharacterDAOIT
 {
 
@@ -124,20 +121,6 @@ public class PlayerCharacterDAOIT
 
     @Autowired
     private JdbcTemplate template;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterEach
-    public void afterEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testActiveCharacterFinder()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterLinkDAOIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterLinkDAOIT.java
@@ -6,22 +6,19 @@ package com.nephest.battlenet.sc2.model.local.dao;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.SocialMedia;
 import com.nephest.battlenet.sc2.model.local.Account;
 import com.nephest.battlenet.sc2.model.local.PlayerCharacter;
 import com.nephest.battlenet.sc2.model.local.PlayerCharacterLink;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import jakarta.validation.ConstraintViolationException;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +27,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class PlayerCharacterLinkDAOIT
 {
 
@@ -46,20 +44,12 @@ public class PlayerCharacterLinkDAOIT
     private PlayerCharacter character;
 
     @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
+    public void beforeEach()
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         account = accountDAO.merge(new Account(null, Partition.GLOBAL, "tag#1"));
         character = playerCharacterDAO.merge(
             new PlayerCharacter(null, account.getId(), Region.EU, 1L, 1, "name#1"));
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterReportDBIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterReportDBIT.java
@@ -5,8 +5,8 @@ package com.nephest.battlenet.sc2.model.local.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -15,13 +15,10 @@ import com.nephest.battlenet.sc2.model.TeamType;
 import com.nephest.battlenet.sc2.model.local.Evidence;
 import com.nephest.battlenet.sc2.model.local.PlayerCharacterReport;
 import com.nephest.battlenet.sc2.model.local.SeasonGenerator;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +27,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class PlayerCharacterReportDBIT
 {
 
@@ -42,13 +40,10 @@ public class PlayerCharacterReportDBIT
     @BeforeEach
     public void beforeEach
     (
-        @Autowired DataSource dataSource,
-        @Autowired SeasonGenerator seasonGenerator,
-        @Autowired Client clickHouseClient
+        @Autowired SeasonGenerator seasonGenerator
         )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         seasonGenerator.generateDefaultSeason
         (
             List.of(Region.EU),
@@ -57,13 +52,6 @@ public class PlayerCharacterReportDBIT
             TeamType.ARRANGED, BaseLeagueTier.LeagueTierType.FIRST, 10
         );
 
-    }
-
-    @AfterEach
-    public void afterEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterReportIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterReportIT.java
@@ -17,11 +17,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.security.SC2PulseAuthority;
 import com.nephest.battlenet.sc2.config.security.WithBlizzardMockUser;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.BaseMatch;
@@ -54,7 +54,6 @@ import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderCharacterDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderMatchDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderSearchDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderTeamStateDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.web.service.PlayerCharacterReportService;
 import com.nephest.battlenet.sc2.web.service.WebServiceTestUtil;
@@ -70,8 +69,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -89,6 +86,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(classes = AllTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class PlayerCharacterReportIT
 {
 
@@ -163,16 +161,13 @@ public class PlayerCharacterReportIT
     @BeforeEach
     public void beforeEach
     (
-        @Autowired DataSource dataSource,
         @Autowired AccountDAO accountDAO,
         @Autowired AccountRoleDAO accountRoleDAO,
         @Autowired WebApplicationContext webApplicationContext,
-        @Autowired SeasonGenerator seasonGenerator,
-        @Autowired Client clickHouseClient
+        @Autowired SeasonGenerator seasonGenerator
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         account = accountDAO.merge(new Account(null, Partition.GLOBAL, BATTLETAG));
         seasonGenerator.generateDefaultSeason
         (
@@ -188,13 +183,6 @@ public class PlayerCharacterReportIT
             .apply(springSecurity())
             .alwaysDo(print())
             .build();
-    }
-
-    @AfterEach
-    public void afterEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterSummaryIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterSummaryIT.java
@@ -9,9 +9,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.Partition;
@@ -30,7 +30,6 @@ import com.nephest.battlenet.sc2.model.local.TeamState;
 import com.nephest.battlenet.sc2.model.local.inner.PlayerCharacterSummary;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyId;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyIdEntry;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.web.controller.CharacterControllerLegacy;
 import com.nephest.battlenet.sc2.web.service.WebServiceTestUtil;
@@ -40,8 +39,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,6 +51,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(classes = AllTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class PlayerCharacterSummaryIT
 {
 
@@ -86,25 +84,15 @@ public class PlayerCharacterSummaryIT
     @BeforeEach
     public void beforeAll
     (
-        @Autowired DataSource dataSource,
-        @Autowired WebApplicationContext webApplicationContext,
-        @Autowired Client clickHouseClient
+        @Autowired WebApplicationContext webApplicationContext
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         mvc = MockMvcBuilders
             .webAppContextSetup(webApplicationContext)
             .apply(springSecurity())
             .alwaysDo(print())
             .build();
-    }
-
-    @AfterEach
-    public void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/ProPlayerAccountIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/ProPlayerAccountIT.java
@@ -7,20 +7,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.local.Account;
 import com.nephest.battlenet.sc2.model.local.PlayerCharacter;
 import com.nephest.battlenet.sc2.model.local.ProPlayer;
 import com.nephest.battlenet.sc2.model.local.ProPlayerAccount;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.util.Set;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -29,6 +25,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class ProPlayerAccountIT
 {
 
@@ -46,20 +43,6 @@ public class ProPlayerAccountIT
 
     @Autowired
     private JdbcTemplate template;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterEach
-    public void afterEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testProtectedFlag()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/ProPlayerIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/ProPlayerIT.java
@@ -8,19 +8,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.local.ProPlayer;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.OptimisticLockingFailureException;
@@ -29,25 +25,12 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class ProPlayerIT
 {
 
     @Autowired
     private ProPlayerDAO proPlayerDAO;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void whenNotExists_thenInsert()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/ProTeamIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/ProTeamIT.java
@@ -5,18 +5,14 @@ package com.nephest.battlenet.sc2.model.local.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.local.ProTeam;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import java.time.OffsetDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
@@ -24,25 +20,12 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class ProTeamIT
 {
 
     @Autowired
     private ProTeamDAO proTeamDAO;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testFindByIds()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/ProTeamMemberIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/ProTeamMemberIT.java
@@ -5,21 +5,17 @@ package com.nephest.battlenet.sc2.model.local.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.local.ProPlayer;
 import com.nephest.battlenet.sc2.model.local.ProTeam;
 import com.nephest.battlenet.sc2.model.local.ProTeamMember;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
@@ -27,6 +23,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class ProTeamMemberIT
 {
 
@@ -38,20 +35,6 @@ public class ProTeamMemberIT
 
     @Autowired
     private ProTeamMemberDAO proTeamMemberDAO;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testFindByIds()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/SeasonIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/SeasonIT.java
@@ -6,20 +6,17 @@ package com.nephest.battlenet.sc2.model.local.dao;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.local.Season;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +25,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class SeasonIT
 {
 
@@ -39,13 +37,10 @@ public class SeasonIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
-        @Autowired SeasonDAO seasonDAO,
-        @Autowired Client clickHouseClient
+        @Autowired SeasonDAO seasonDAO
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         OffsetDateTime start = SC2Pulse.offsetDateTime(2020, 1, 1);
         seasons = new ArrayList<>();
         for(Region region : Region.values())
@@ -53,13 +48,6 @@ public class SeasonIT
                 start, start.plusMonths(1))));
         seasons.add(seasonDAO.create(new Season(null, 2, Region.EU, 2020, 2,
             start.plusMonths(1), start.plusMonths(2))));
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/SeasonStructureIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/SeasonStructureIT.java
@@ -11,8 +11,8 @@ import static com.nephest.battlenet.sc2.model.BaseLeagueTier.LeagueTierType.THIR
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -22,7 +22,6 @@ import com.nephest.battlenet.sc2.model.Version;
 import com.nephest.battlenet.sc2.model.local.League;
 import com.nephest.battlenet.sc2.model.local.LeagueTier;
 import com.nephest.battlenet.sc2.model.local.Season;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -34,9 +33,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -48,6 +45,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class SeasonStructureIT
 {
 
@@ -67,15 +65,12 @@ public class SeasonStructureIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
         @Autowired SeasonDAO seasonDAO,
         @Autowired LeagueDAO leagueDAO,
-        @Autowired LeagueTierDAO leagueTierDAO,
-        @Autowired Client clickHouseClient
+        @Autowired LeagueTierDAO leagueTierDAO
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         OffsetDateTime seasonStart = SC2Pulse.offsetDateTime();
         SEASONS = Arrays.stream(Region.values())
             .map(region->new Season(null, 1, region, seasonStart.getYear(), 1,
@@ -98,13 +93,6 @@ public class SeasonStructureIT
                     Integer.parseInt("" + league.getId() + type.ordinal()),
                     Integer.parseInt("" + league.getId() + type.ordinal()) + 1));
         TIERS.forEach(leagueTierDAO::create);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     public static Stream<Arguments> testFindLeaguesByUids()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/SocialMediaLinkIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/SocialMediaLinkIT.java
@@ -7,23 +7,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.SocialMedia;
 import com.nephest.battlenet.sc2.model.local.ProPlayer;
 import com.nephest.battlenet.sc2.model.local.SocialMediaLink;
 import com.nephest.battlenet.sc2.model.local.SocialMediaUserId;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.time.OffsetDateTime;
 import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
@@ -31,6 +27,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class SocialMediaLinkIT
 {
 
@@ -39,20 +36,6 @@ public class SocialMediaLinkIT
 
     @Autowired
     private SocialMediaLinkDAO socialMediaLinkDAO;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterEach
-    public void afterEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     private static void verifyLink
     (

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/SqlSyntaxIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/SqlSyntaxIT.java
@@ -9,9 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
 import com.nephest.battlenet.sc2.config.security.SC2PulseAuthority;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -30,7 +30,6 @@ import com.nephest.battlenet.sc2.model.local.Team;
 import com.nephest.battlenet.sc2.model.local.TeamMember;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyId;
 import com.nephest.battlenet.sc2.model.twitch.dao.TwitchVideoDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.PostgreSQLUtils;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.util.Arrays;
@@ -38,9 +37,6 @@ import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -53,6 +49,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class SqlSyntaxIT
 {
     @Autowired
@@ -117,20 +114,6 @@ public class SqlSyntaxIT
 
     @Autowired
     private JdbcTemplate template;
-
-    @BeforeAll
-    public static void beforeAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-        throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     /*TODO
         Split this abomination into proper tests

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/TeamIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/TeamIT.java
@@ -7,8 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -21,7 +21,6 @@ import com.nephest.battlenet.sc2.model.local.StatefulBasicEntityOperations;
 import com.nephest.battlenet.sc2.model.local.Team;
 import com.nephest.battlenet.sc2.model.local.TeamState;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyId;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.math.BigInteger;
 import java.time.OffsetDateTime;
@@ -32,12 +31,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
 import org.apache.commons.lang3.SerializationUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -50,6 +47,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class TeamIT
 {
 
@@ -73,26 +71,16 @@ public class TeamIT
         TeamIT.operations = operations;
     }
 
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
     @AfterEach
     public void afterEach
     (
-        @Autowired DataSource dataSource,
-        @Autowired List<StatefulBasicEntityOperations<Team>> statefulBasicEntityOperations,
-        @Autowired Client clickHouseClient
+        @Autowired List<StatefulBasicEntityOperations<Team>> statefulBasicEntityOperations
     )
     throws Exception
     {
         for(StatefulBasicEntityOperations<Team> ops : statefulBasicEntityOperations)
             for(Region region : Region.values())
                 ops.clear(region);
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/TeamStateDAOIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/TeamStateDAOIT.java
@@ -9,8 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -25,16 +25,12 @@ import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyUid;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderTeamState;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderTeamStateDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LegacySearchIT;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.web.service.StatsService;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
@@ -42,6 +38,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class TeamStateDAOIT
 {
 
@@ -62,20 +59,6 @@ public class TeamStateDAOIT
 
     @Autowired
     private LadderTeamStateDAO ladderTeamStateDAO;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterEach
-    public void afterEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testDifferentMmrHistoryLength()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/ladder/dao/Ladder1v1LeagueStatsIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/ladder/dao/Ladder1v1LeagueStatsIT.java
@@ -1,12 +1,12 @@
-// Copyright (C) 2020-2025 Oleksandr Masniuk
+// Copyright (C) 2020-2026 Oleksandr Masniuk
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 package com.nephest.battlenet.sc2.model.local.ladder.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -16,14 +16,10 @@ import com.nephest.battlenet.sc2.model.TeamType;
 import com.nephest.battlenet.sc2.model.local.SeasonGenerator;
 import com.nephest.battlenet.sc2.model.local.dao.LeagueStatsDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.MergedLadderSearchStatsResult;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -34,6 +30,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class Ladder1v1LeagueStatsIT
 {
 
@@ -51,24 +48,6 @@ public class Ladder1v1LeagueStatsIT
 
     @Autowired @Qualifier("sc2StatsConversionService")
     ConversionService conversionService;
-
-    @BeforeEach
-    public void beforeEach
-    (
-        @Autowired DataSource dataSource,
-        @Autowired Client clickHouseClient
-    )
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testRaceTeamCount()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/ladder/dao/LadderCharacterTeamSearchIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/ladder/dao/LadderCharacterTeamSearchIT.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2025 Oleksandr Masniuk
+// Copyright (C) 2020-2026 Oleksandr Masniuk
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 package com.nephest.battlenet.sc2.model.local.ladder.dao;
@@ -9,10 +9,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.Partition;
@@ -29,13 +29,10 @@ import com.nephest.battlenet.sc2.model.local.Team;
 import com.nephest.battlenet.sc2.model.local.dao.DivisionDAO;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyId;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderTeam;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.web.controller.CharacterController;
 import java.util.List;
 import java.util.stream.LongStream;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,6 +49,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = AllTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class LadderCharacterTeamSearchIT
 {
 
@@ -78,14 +76,10 @@ public class LadderCharacterTeamSearchIT
     public static void beforeAll
     (
         @Autowired DivisionDAO divisionDAO,
-        @Autowired SeasonGenerator seasonGenerator,
-        @Autowired DataSource dataSource,
-        @Autowired Client clickHouseClient
+        @Autowired SeasonGenerator seasonGenerator
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-
         Region region = Region.EU;
         Season season1 = new Season(null, 1, region, 2020, 1,
             SC2Pulse.offsetDateTime(2020, 1, 1), SC2Pulse.offsetDateTime(2020, 2, 1));
@@ -139,13 +133,6 @@ public class LadderCharacterTeamSearchIT
             season1, new BaseLeague(BaseLeague.LeagueType.BRONZE, QueueType.LOTV_4V4, TEAM_TYPE), TIER_TYPE, bronze1v1,
             TeamLegacyId.trusted("10005"), 0L, 1, 2, 3, 4, characters[2]
         );
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/ladder/dao/LadderProPlayerAccountIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/ladder/dao/LadderProPlayerAccountIT.java
@@ -1,12 +1,12 @@
-// Copyright (C) 2020-2025 Oleksandr Masniuk
+// Copyright (C) 2020-2026 Oleksandr Masniuk
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 package com.nephest.battlenet.sc2.model.local.ladder.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.local.Account;
@@ -17,14 +17,10 @@ import com.nephest.battlenet.sc2.model.local.SeasonGenerator;
 import com.nephest.battlenet.sc2.model.local.dao.ProPlayerAccountDAO;
 import com.nephest.battlenet.sc2.model.local.dao.ProPlayerDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.RevealerStats;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,6 +28,7 @@ import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(classes = AllTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class LadderProPlayerAccountIT
 {
 
@@ -46,24 +43,6 @@ public class LadderProPlayerAccountIT
 
     @Autowired
     private SeasonGenerator seasonGenerator;
-
-    @BeforeEach
-    public void beforeEach
-    (
-        @Autowired DataSource dataSource,
-        @Autowired Client clickHouseClient
-    )
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testFindRevealerStats()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/ladder/dao/LadderProPlayerIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/ladder/dao/LadderProPlayerIT.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2025 Oleksandr Masniuk
+// Copyright (C) 2020-2026 Oleksandr Masniuk
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 package com.nephest.battlenet.sc2.model.local.ladder.dao;
@@ -6,16 +6,12 @@ package com.nephest.battlenet.sc2.model.local.ladder.dao;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.local.ProPlayer;
 import com.nephest.battlenet.sc2.model.local.dao.ProPlayerDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderProPlayer;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import java.util.Set;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
@@ -23,6 +19,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class LadderProPlayerIT
 {
 
@@ -31,24 +28,6 @@ public class LadderProPlayerIT
 
     @Autowired
     private LadderProPlayerDAO ladderProPlayerDAO;
-
-    @BeforeEach
-    public void beforeEach
-    (
-        @Autowired DataSource dataSource,
-        @Autowired Client clickHouseClient
-    )
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void whenNoLinks_thenReturnEmptyCollection()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/ladder/dao/LadderSearchIndependentEmptyIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/ladder/dao/LadderSearchIndependentEmptyIT.java
@@ -7,10 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.local.Account;
@@ -19,13 +19,10 @@ import com.nephest.battlenet.sc2.model.local.dao.AccountDAO;
 import com.nephest.battlenet.sc2.model.local.dao.PlayerCharacterDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderDistinctCharacter;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderPlayerSearchStats;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -41,6 +38,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 @SpringBootTest(classes = AllTestConfig.class)
 @TestPropertySource("classpath:application.properties")
 @AutoConfigureMockMvc
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class LadderSearchIndependentEmptyIT
 {
 
@@ -56,24 +54,14 @@ public class LadderSearchIndependentEmptyIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
         @Autowired AccountDAO accountDAO,
-        @Autowired PlayerCharacterDAO playerCharacterDAO,
-        @Autowired Client clickHouseClient
+        @Autowired PlayerCharacterDAO playerCharacterDAO
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         account = accountDAO.merge(new Account(null, Partition.GLOBAL, "btag#1"));
         character = playerCharacterDAO.merge(new PlayerCharacter(
             null, account.getId(), Region.EU, 1L, 1, "name#1"));
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     public static Stream<Arguments> testEmptyStats()

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/ladder/dao/LadderSearchIndependentIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/ladder/dao/LadderSearchIndependentIT.java
@@ -14,10 +14,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.security.WithBlizzardMockUser;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.Partition;
@@ -48,14 +48,11 @@ import com.nephest.battlenet.sc2.model.local.dao.TeamMemberDAO;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyId;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderDistinctCharacter;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderPlayerSearchStats;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,6 +65,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(classes = AllTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class LadderSearchIndependentIT
 {
 
@@ -124,25 +122,15 @@ public class LadderSearchIndependentIT
     @BeforeEach
     public void beforeEach
     (
-        @Autowired DataSource dataSource,
-        @Autowired WebApplicationContext webApplicationContext,
-        @Autowired Client clickHouseClient
+        @Autowired WebApplicationContext webApplicationContext
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         mvc = MockMvcBuilders
             .webAppContextSetup(webApplicationContext)
             .apply(springSecurity())
             .alwaysDo(print())
             .build();
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/ladder/dao/LadderSeasonStateDAOIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/ladder/dao/LadderSeasonStateDAOIT.java
@@ -7,8 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.Partition;
@@ -33,15 +33,12 @@ import com.nephest.battlenet.sc2.model.local.dao.TeamMemberDAO;
 import com.nephest.battlenet.sc2.model.local.dao.TeamStateDAO;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyId;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderSeasonState;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.web.service.StatsService;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,6 +47,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class LadderSeasonStateDAOIT
 {
 
@@ -80,13 +78,10 @@ public class LadderSeasonStateDAOIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
-        @Autowired SeasonGenerator seasonGenerator,
-        @Autowired Client clickHouseClient
+        @Autowired SeasonGenerator seasonGenerator
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         seasonGenerator.generateDefaultSeason
         (
             List.of(Region.values()),
@@ -96,13 +91,6 @@ public class LadderSeasonStateDAOIT
             BaseLeagueTier.LeagueTierType.FIRST,
             0
         );
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/ladder/dao/LegacySearchIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/ladder/dao/LegacySearchIT.java
@@ -5,8 +5,8 @@ package com.nephest.battlenet.sc2.model.local.ladder.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -29,7 +29,6 @@ import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyIdEntry;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyUid;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderTeam;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderTeamState;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.web.service.StatsService;
 import java.time.OffsetDateTime;
@@ -39,8 +38,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,6 +48,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class LegacySearchIT
 {
 
@@ -81,17 +79,14 @@ public class LegacySearchIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
         @Autowired SeasonGenerator seasonGenerator,
         @Autowired DivisionDAO divisionDAO,
         @Autowired TeamDAO teamDAO,
         @Autowired TeamMemberDAO teamMemberDAO,
-        @Autowired TeamStateDAO teamStateDAO,
-        @Autowired Client clickHouseClient
+        @Autowired TeamStateDAO teamStateDAO
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         ODT = SC2Pulse.offsetDateTime().minusDays(180);
         OffsetDateTime start = SC2Pulse.offsetDateTime().minusYears(1);
         List<Season> seasons = List.of
@@ -204,13 +199,6 @@ public class LegacySearchIT
         teamDAO.merge(Set.of(team1));
         teamStateDAO.saveState(Set.of(TeamState.of(team1)));
         return team1;
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/model/twitch/TwitchIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/twitch/TwitchIT.java
@@ -6,21 +6,17 @@ package com.nephest.battlenet.sc2.model.twitch;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.local.dao.ProPlayerDAO;
 import com.nephest.battlenet.sc2.model.local.dao.SocialMediaLinkDAO;
 import com.nephest.battlenet.sc2.model.twitch.dao.TwitchUserDAO;
 import com.nephest.battlenet.sc2.model.twitch.dao.TwitchVideoDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.time.OffsetDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -29,6 +25,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class TwitchIT
 {
 
@@ -46,20 +43,6 @@ public class TwitchIT
 
     @Autowired
     private JdbcTemplate template;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterEach
-    public void afterEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testChain()

--- a/src/test/java/com/nephest/battlenet/sc2/model/util/DbTestUtil.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/util/DbTestUtil.java
@@ -5,57 +5,11 @@ package com.nephest.battlenet.sc2.model.util;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
-import com.clickhouse.client.api.command.CommandResponse;
-import com.nephest.battlenet.sc2.util.TestUtil;
-import java.sql.Connection;
 import java.sql.Statement;
 import java.util.Arrays;
-import java.util.concurrent.CompletableFuture;
-import javax.sql.DataSource;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.jdbc.datasource.init.ScriptUtils;
 
 public class DbTestUtil
 {
-
-    public static void initDb(DataSource dataSource, Client clickHouseClient)
-    throws Exception
-    {
-        clearDb(dataSource, clickHouseClient);
-        CompletableFuture<CommandResponse> clickHouseInitTask
-            = clickHouseClient.execute(TestUtil.readResource(
-                DbTestUtil.class,
-                "schema-clickhouse.sql"
-        ));
-        try(Connection connection = dataSource.getConnection())
-        {
-            ScriptUtils.executeSqlScript(connection, new ClassPathResource("schema-drop-postgres.sql"));
-            ScriptUtils.executeSqlScript(connection, new ClassPathResource("schema-postgres.sql"));
-        }
-        finally
-        {
-            clickHouseInitTask.get().close();
-        }
-    }
-
-    public static void clearDb(DataSource dataSource, Client clickHouseClient)
-    throws Exception
-    {
-        CompletableFuture<CommandResponse> clickHouseClearTask
-            = clickHouseClient.execute(TestUtil.readResource(
-                DbTestUtil.class,
-                "schema-drop-clickhouse.sql"
-        ));
-        try(Connection connection = dataSource.getConnection())
-        {
-            ScriptUtils.executeSqlScript(connection, new ClassPathResource("schema-drop-postgres.sql"));
-        }
-        finally
-        {
-            clickHouseClearTask.get().close();
-        }
-    }
 
     public static boolean isBatchUpdateValid(int rowsChanged, int expected)
     {

--- a/src/test/java/com/nephest/battlenet/sc2/model/util/PostgreSQLUtilsIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/util/PostgreSQLUtilsIT.java
@@ -6,13 +6,9 @@ package com.nephest.battlenet.sc2.model.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.DatabaseTestConfig;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import java.util.Set;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -23,25 +19,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringJUnitConfig(classes = DatabaseTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class PostgreSQLUtilsIT
 {
 
     @Autowired
     private PostgreSQLUtils postgreSQLUtils;
-
-    @BeforeEach
-    public void beforeAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterEach
-    public void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @ValueSource(booleans = {true, false})
     @ParameterizedTest

--- a/src/test/java/com/nephest/battlenet/sc2/model/util/TestDatabaseLifecycleService.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/util/TestDatabaseLifecycleService.java
@@ -42,7 +42,6 @@ public class TestDatabaseLifecycleService
             );
             try(var connection = dataSource.getConnection())
             {
-                ScriptUtils.executeSqlScript(connection, new ClassPathResource("schema-drop-postgres.sql"));
                 ScriptUtils.executeSqlScript(connection, new ClassPathResource("schema-postgres.sql"));
             }
             finally

--- a/src/test/java/com/nephest/battlenet/sc2/model/util/TestDatabaseLifecycleService.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/util/TestDatabaseLifecycleService.java
@@ -1,0 +1,86 @@
+// Copyright (C) 2020-2026 Oleksandr Masniuk
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.nephest.battlenet.sc2.model.util;
+
+import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.command.CommandResponse;
+import com.nephest.battlenet.sc2.util.TestUtil;
+import java.util.concurrent.CompletableFuture;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TestDatabaseLifecycleService
+{
+
+    private final DataSource dataSource;
+    private final Client clickHouseClient;
+
+    @Autowired
+    public TestDatabaseLifecycleService(DataSource dataSource, Client clickHouseClient)
+    {
+        this.dataSource = dataSource;
+        this.clickHouseClient = clickHouseClient;
+    }
+
+    public void initDb()
+    {
+        try
+        {
+            clearDb();
+            CompletableFuture<CommandResponse> clickHouseInitTask = clickHouseClient.execute
+            (
+                TestUtil.readResource
+                (
+                    TestDatabaseLifecycleService.class,
+                    "schema-clickhouse.sql"
+                )
+            );
+            try(var connection = dataSource.getConnection())
+            {
+                ScriptUtils.executeSqlScript(connection, new ClassPathResource("schema-drop-postgres.sql"));
+                ScriptUtils.executeSqlScript(connection, new ClassPathResource("schema-postgres.sql"));
+            }
+            finally
+            {
+                clickHouseInitTask.get().close();
+            }
+        }
+        catch(Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void clearDb()
+    {
+        try
+        {
+            CompletableFuture<CommandResponse> clickHouseClearTask = clickHouseClient.execute
+            (
+                TestUtil.readResource
+                (
+                    TestDatabaseLifecycleService.class,
+                    "schema-drop-clickhouse.sql"
+                )
+            );
+            try(var connection = dataSource.getConnection())
+            {
+                ScriptUtils.executeSqlScript(connection, new ClassPathResource("schema-drop-postgres.sql"));
+            }
+            finally
+            {
+                clickHouseClearTask.get().close();
+            }
+        }
+        catch(Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/test/java/com/nephest/battlenet/sc2/selenium/GeneralSeleniumIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/selenium/GeneralSeleniumIT.java
@@ -15,19 +15,17 @@ import static org.openqa.selenium.support.ui.ExpectedConditions.invisibilityOfEl
 import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOf;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.discord.DiscordTest;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.blizzard.BlizzardTest;
 import com.nephest.battlenet.sc2.model.local.SeasonGenerator;
 import com.nephest.battlenet.sc2.model.local.dao.AccountDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.TestDbInitializer;
 import com.nephest.battlenet.sc2.web.util.WebContextUtil;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
-import javax.sql.DataSource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,6 +61,7 @@ import org.testcontainers.selenium.BrowserWebDriverContainer;
 )
 @ActiveProfiles({"dev", "default"})
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class GeneralSeleniumIT
 {
 
@@ -91,8 +90,6 @@ public class GeneralSeleniumIT
     @BeforeAll
     public static void init
     (
-        @Autowired DataSource dataSource,
-        @Autowired Client clickHouseClient,
         @Autowired AccountDAO accountDAO,
         @Autowired ServletWebServerApplicationContext webServerAppCtxt,
         @Value("${org.testcontainers.selenium.image.name}") String seleniumImageName,
@@ -108,7 +105,6 @@ public class GeneralSeleniumIT
         driver = initDriver(seleniumImageName, headless, testContainersHost, root);
         wait = new WebDriverWait(driver, Duration.ofMillis(TIMEOUT_MILLIS));
         js = (JavascriptExecutor) driver;
-        DbTestUtil.initDb(dataSource, clickHouseClient);
     }
 
     private static WebDriver initDriver
@@ -179,12 +175,11 @@ public class GeneralSeleniumIT
     }
 
     @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
+    public static void afterAll()
     throws Exception
     {
         driver.close();
         BROWSER_CONTAINER.close();
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/service/AccountFollowingIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/service/AccountFollowingIT.java
@@ -13,9 +13,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.security.WithBlizzardMockUser;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.Partition;
@@ -36,11 +36,8 @@ import com.nephest.battlenet.sc2.model.local.dao.TeamDAO;
 import com.nephest.battlenet.sc2.model.local.dao.TeamMemberDAO;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyId;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderSearchDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.util.List;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,6 +50,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(classes = AllTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class AccountFollowingIT
 {
 
@@ -93,25 +91,15 @@ public class AccountFollowingIT
     @BeforeEach
     public void beforeEach
     (
-        @Autowired DataSource dataSource,
-        @Autowired WebApplicationContext webApplicationContext,
-        @Autowired Client clickHouseClient
+        @Autowired WebApplicationContext webApplicationContext
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         mvc = MockMvcBuilders
             .webAppContextSetup(webApplicationContext)
             .apply(springSecurity())
             .alwaysDo(print())
             .build();
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/web/controller/AdminControllerIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/controller/AdminControllerIT.java
@@ -9,18 +9,14 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.security.SC2PulseAuthority;
 import com.nephest.battlenet.sc2.config.security.WithBlizzardMockUser;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.blizzard.BlizzardTest;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.web.service.MatchService;
 import java.time.Duration;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -33,6 +29,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = {AllTestConfig.class})
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class AdminControllerIT
 {
 
@@ -41,20 +38,6 @@ public class AdminControllerIT
 
     @Autowired
     private MatchService matchService;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/web/controller/UserControllerIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/controller/UserControllerIT.java
@@ -6,21 +6,18 @@ package com.nephest.battlenet.sc2.web.controller;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.security.SC2PulseAuthority;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.local.Account;
 import com.nephest.battlenet.sc2.model.local.SeasonGenerator;
 import com.nephest.battlenet.sc2.model.local.dao.AccountRoleDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -38,6 +35,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = {AllTestConfig.class})
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class UserControllerIT
 {
 
@@ -56,14 +54,11 @@ public class UserControllerIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
         @Autowired SeasonGenerator seasonGenerator,
-        @Autowired AccountRoleDAO accountRoleDAO,
-        @Autowired Client clickHouseClient
+        @Autowired AccountRoleDAO accountRoleDAO
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         accounts = seasonGenerator.generateAccounts(Partition.GLOBAL, "tag", 10);
         accountRoleDAO.addRoles
         (
@@ -73,13 +68,6 @@ public class UserControllerIT
         accountRoleDAO.addRoles(2L, EnumSet.of(SC2PulseAuthority.MODERATOR));
         accountRoleDAO.addRoles(3L, EnumSet.of(SC2PulseAuthority.REVEALER));
         accountRoleDAO.addRoles(4L, EnumSet.of(SC2PulseAuthority.ADMIN));
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     public static Stream<Arguments> testGetByRole()

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/AccountServiceIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/AccountServiceIT.java
@@ -12,16 +12,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.security.WithBlizzardMockUser;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.local.Account;
 import com.nephest.battlenet.sc2.model.local.SeasonGenerator;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -36,6 +32,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = {AllTestConfig.class})
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class AccountServiceIT
 {
 
@@ -50,20 +47,6 @@ public class AccountServiceIT
 
     @Autowired
     private MockMvc mvc;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testSetPassword()

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/BlizzardDataServiceIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/BlizzardDataServiceIT.java
@@ -12,10 +12,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.security.WithBlizzardMockUser;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.blizzard.BlizzardFullPlayerCharacter;
@@ -26,16 +26,13 @@ import com.nephest.battlenet.sc2.model.local.Season;
 import com.nephest.battlenet.sc2.model.local.dao.AccountDAO;
 import com.nephest.battlenet.sc2.model.local.dao.PlayerCharacterDAO;
 import com.nephest.battlenet.sc2.model.local.dao.SeasonDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.web.controller.BlizzardDataController;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,6 +46,7 @@ import org.springframework.web.context.WebApplicationContext;
 @BlizzardTest
 @SpringBootTest(classes = {AllTestConfig.class})
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class BlizzardDataServiceIT
 {
 
@@ -87,12 +85,9 @@ public class BlizzardDataServiceIT
     @BeforeEach
     public void beforeEach
     (
-        @Autowired DataSource dataSource,
-        @Autowired WebApplicationContext webApplicationContext,
-        @Autowired Client clickHouseClient
+        @Autowired WebApplicationContext webApplicationContext
     ) throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         mvc = MockMvcBuilders
             .webAppContextSetup(webApplicationContext)
             .apply(springSecurity())
@@ -118,13 +113,6 @@ public class BlizzardDataServiceIT
         acc2 = accountDAO.merge(new Account(null, Partition.GLOBAL, "user#2"));
         char2_1 = playerCharacterDAO
             .merge(new PlayerCharacter(null, acc2.getId(), Region.EU, 3L, 3, "name#3"));
-    }
-
-    @AfterEach
-    public void afterEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/BlizzardSC2APIIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/BlizzardSC2APIIT.java
@@ -14,10 +14,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.security.SC2PulseAuthority;
 import com.nephest.battlenet.sc2.config.security.WithBlizzardMockUser;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.PlayerCharacterNaturalId;
@@ -35,7 +35,6 @@ import com.nephest.battlenet.sc2.model.blizzard.BlizzardTest;
 import com.nephest.battlenet.sc2.model.blizzard.BlizzardTierDivision;
 import com.nephest.battlenet.sc2.model.local.Patch;
 import com.nephest.battlenet.sc2.model.local.PlayerCharacter;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.time.Duration;
 import java.util.Arrays;
@@ -43,7 +42,6 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -69,6 +67,7 @@ import reactor.util.function.Tuples;
 @SpringBootTest(classes = {AllTestConfig.class})
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class BlizzardSC2APIIT
 {
 
@@ -110,27 +109,21 @@ public class BlizzardSC2APIIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired BlizzardSC2API api,
-        @Autowired DataSource dataSource,
-        @Autowired Client clickHouseClient
+        @Autowired BlizzardSC2API api
     )
     throws Exception
     {
         originalClient = WebServiceTestUtil.fastTimers(api);
-        DbTestUtil.initDb(dataSource, clickHouseClient);
     }
 
     @AfterAll
     public static void afterAll
     (
-        @Autowired BlizzardSC2API api,
-        @Autowired DataSource dataSource,
-        @Autowired Client clickHouseClient
+        @Autowired BlizzardSC2API api
     )
     throws Exception
     {
         WebServiceTestUtil.revertFastTimers(api, originalClient);
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test @Order(1) @Disabled("Blizzard API fails too often now, ignore this test until it becomes more stable")

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/CharacterIdSearchIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/CharacterIdSearchIT.java
@@ -6,9 +6,9 @@ package com.nephest.battlenet.sc2.web.service;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.BasePlayerCharacter;
@@ -23,17 +23,13 @@ import com.nephest.battlenet.sc2.model.local.Season;
 import com.nephest.battlenet.sc2.model.local.SeasonGenerator;
 import com.nephest.battlenet.sc2.model.local.dao.AccountDAO;
 import com.nephest.battlenet.sc2.model.local.dao.PlayerCharacterDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -49,6 +45,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = {AllTestConfig.class})
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class CharacterIdSearchIT
 {
 
@@ -69,20 +66,6 @@ public class CharacterIdSearchIT
 
     @Autowired @Qualifier("mvcConversionService")
     private ConversionService mvcConversionService;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     public static PlayerCharacter fromId(Long id)
     {

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/ClanMemberEventIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/ClanMemberEventIT.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2025 Oleksandr Masniuk
+// Copyright (C) 2020-2026 Oleksandr Masniuk
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 package com.nephest.battlenet.sc2.web.service;
@@ -10,10 +10,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.Region;
@@ -30,7 +30,6 @@ import com.nephest.battlenet.sc2.model.local.dao.PlayerCharacterStatsDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderClanMemberEvents;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderDistinctCharacter;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderPlayerSearchStats;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.model.validation.CursorNavigableResult;
 import java.time.Duration;
@@ -40,9 +39,7 @@ import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,6 +54,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = {AllTestConfig.class})
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class ClanMemberEventIT
 {
 
@@ -89,11 +87,9 @@ public class ClanMemberEventIT
     private Clan[] clans;
 
     @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
+    public void beforeEach()
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-
         accounts = seasonGenerator.generateAccounts(Partition.GLOBAL, "acc", 10);
         characters = seasonGenerator.generateCharacters("name", accounts, Region.EU, 100L);
         seasonGenerator.generateDefaultSeason(0);
@@ -116,13 +112,6 @@ public class ClanMemberEventIT
             new ClanMember(characters[4].getId(), clans[3].getId()),
             new ClanMember(characters[5].getId(), clans[4].getId())
         ));
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/DiscordAPIIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/DiscordAPIIT.java
@@ -8,16 +8,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.security.WithBlizzardMockUser;
 import com.nephest.battlenet.sc2.discord.DiscordTest;
 import com.nephest.battlenet.sc2.discord.IdentifiableEntity;
 import com.nephest.battlenet.sc2.discord.InstallationData;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import java.io.IOException;
-import javax.sql.DataSource;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
@@ -37,6 +35,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 @DiscordTest
 @SpringBootTest(classes = {AllTestConfig.class})
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class DiscordAPIIT
 {
 
@@ -52,19 +51,17 @@ public class DiscordAPIIT
     private static WebClient originalClient;
 
     @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
+    public void beforeEach()
     throws Exception
     {
         originalClient = WebServiceTestUtil.fastTimers(api);
-        DbTestUtil.initDb(dataSource, clickHouseClient);
     }
 
     @AfterEach
-    public void afterEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
+    public void afterEach()
     throws Exception
     {
         WebServiceTestUtil.revertFastTimers(api, originalClient);
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/DiscordIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/DiscordIT.java
@@ -20,13 +20,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.security.WithBlizzardMockUser;
 import com.nephest.battlenet.sc2.discord.DiscordTest;
 import com.nephest.battlenet.sc2.discord.SpringDiscordClient;
 import com.nephest.battlenet.sc2.discord.connection.ApplicationRoleConnection;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.Partition;
@@ -52,14 +52,12 @@ import com.nephest.battlenet.sc2.model.local.dao.PlayerCharacterStatsDAO;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyId;
 import com.nephest.battlenet.sc2.model.local.ladder.common.CommonCharacter;
 import com.nephest.battlenet.sc2.model.local.ladder.common.CommonPersonalData;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.service.EventService;
 import com.nephest.battlenet.sc2.web.util.MonoUtil;
 import discord4j.common.util.Snowflake;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.object.entity.User;
-import java.sql.Connection;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -68,7 +66,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import javax.sql.DataSource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -96,6 +93,7 @@ import reactor.util.function.Tuples;
 @DiscordTest
 @SpringBootTest(classes = AllTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class DiscordIT
 {
 
@@ -144,14 +142,10 @@ public class DiscordIT
     @BeforeEach
     public void beforeEach
     (
-        @Autowired DataSource dataSource,
-        @Autowired WebApplicationContext webApplicationContext,
-        @Autowired Client clickHouseClient
+        @Autowired WebApplicationContext webApplicationContext
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-
         mvc = MockMvcBuilders
             .webAppContextSetup(webApplicationContext)
             .apply(springSecurity())
@@ -171,14 +165,11 @@ public class DiscordIT
     @AfterAll
     public static void afterAll
     (
-        @Autowired DataSource dataSource,
-        @Autowired DiscordService discordService,
-        @Autowired Client clickHouseClient
+        @Autowired DiscordService discordService
     )
     throws Exception
     {
         discordService.setDiscordAPI(originalAPI);
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/GroupIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/GroupIT.java
@@ -7,9 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.IdField;
@@ -35,7 +35,6 @@ import com.nephest.battlenet.sc2.model.local.ladder.LadderDistinctCharacter;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderPlayerSearchStats;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderProPlayer;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderProPlayerDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.web.controller.ClanController;
 import com.nephest.battlenet.sc2.web.controller.group.CharacterGroupArgumentResolver;
@@ -49,10 +48,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -67,6 +63,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = AllTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class GroupIT
 {
 
@@ -103,20 +100,6 @@ public class GroupIT
     @Autowired @Qualifier("mvcConversionService")
     private ConversionService mvcConversionService;
 
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testGetGroup()

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/LadderSearchIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/LadderSearchIT.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2025 Oleksandr Masniuk
+// Copyright (C) 2020-2026 Oleksandr Masniuk
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 package com.nephest.battlenet.sc2.web.service;
@@ -12,10 +12,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -48,7 +48,6 @@ import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderStatsDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderTeamStateDAO;
 import com.nephest.battlenet.sc2.model.navigation.Cursor;
 import com.nephest.battlenet.sc2.model.navigation.NavigationDirection;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.model.validation.CursorNavigableResult;
 import java.time.OffsetDateTime;
@@ -63,7 +62,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -85,6 +83,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = AllTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class LadderSearchIT
 {
 
@@ -138,7 +137,6 @@ public class LadderSearchIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
         @Autowired SeasonGenerator generator,
         @Autowired QueueStatsDAO queueStatsDAO,
         @Autowired LeagueStatsDAO leagueStatsDAO,
@@ -149,13 +147,10 @@ public class LadderSearchIT
         @Autowired TeamStateDAO teamStateDAO,
         @Autowired PopulationStateDAO populationStateDAO,
         @Autowired LadderSearchDAO ladderSearchDAO,
-        @Autowired JdbcTemplate template,
-        @Autowired Client clickHouseClient
+        @Autowired JdbcTemplate template
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-
         List<Season> seasons = new ArrayList<>();
         for(Region region : REGIONS) seasons.add(new Season(
             null, DEFAULT_SEASON_ID, region,
@@ -237,13 +232,10 @@ public class LadderSearchIT
     @AfterAll
     public static void afterAll
     (
-        @Autowired DataSource dataSource,
-        @Autowired LadderSearchDAO ladderSearchDAO,
-        @Autowired Client clickHouseClient
+        @Autowired LadderSearchDAO ladderSearchDAO
     )
         throws Exception
     {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
         ladderSearchDAO.setResultsPerPage(initialResultsPerPage);
     }
 

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/LadderUpdateIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/LadderUpdateIT.java
@@ -7,15 +7,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.QueueType;
 import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.local.LadderUpdate;
 import com.nephest.battlenet.sc2.model.local.Season;
 import com.nephest.battlenet.sc2.model.local.dao.LadderUpdateDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.service.EventService;
 import java.time.Duration;
@@ -27,9 +26,7 @@ import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,6 +36,7 @@ import reactor.core.Disposable;
 
 @SpringBootTest(classes = AllTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class LadderUpdateIT
 {
 
@@ -52,18 +50,10 @@ public class LadderUpdateIT
     private UpdateService updateService;
 
     @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
+    public void beforeEach()
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         updateService.setPreviousLadderUpdateOffsetDateTime(null);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/MapStatsFilmCrossTierIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/MapStatsFilmCrossTierIT.java
@@ -15,9 +15,9 @@ import static com.nephest.battlenet.sc2.web.service.MapStatsFilmTestService.FRAM
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.Race;
@@ -37,7 +37,6 @@ import com.nephest.battlenet.sc2.model.local.dao.PopulationStateDAO;
 import com.nephest.battlenet.sc2.model.local.dao.TeamDAO;
 import com.nephest.battlenet.sc2.model.local.dao.TeamStateDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderMapStatsFilm;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.service.EventService;
 import java.util.Arrays;
@@ -47,7 +46,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -68,6 +66,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = AllTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class MapStatsFilmCrossTierIT
 {
 
@@ -87,7 +86,6 @@ public class MapStatsFilmCrossTierIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
         @Autowired MapService mapService,
         @Autowired SeasonGenerator seasonGenerator,
         @Autowired LeagueStatsDAO leagueStatsDAO,
@@ -99,12 +97,10 @@ public class MapStatsFilmCrossTierIT
         @Autowired MatchParticipantDAO matchParticipantDAO,
         @Autowired EventService eventService,
         @Autowired MapStatsFilmSpecDAO mapStatsFilmSpecDAO,
-        @Autowired MapStatsFilmTestService mapStatsFilmTestService,
-        @Autowired Client clickHouseClient
+        @Autowired MapStatsFilmTestService mapStatsFilmTestService
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         mapService.getMapStatsInstant().setValue(SC2Pulse.instant());
         mapService.setDbInitialized(false);
         mapStatsFilmTestService.generateFilms((startFrom)->{
@@ -136,13 +132,10 @@ public class MapStatsFilmCrossTierIT
     @AfterAll
     public static void afterAll
     (
-        @Autowired DataSource dataSource,
-        @Autowired MapService mapService,
-        @Autowired Client clickHouseClient
+        @Autowired MapService mapService
     )
     throws Exception
     {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
         mapService.getMapStatsInstant().setValue(SC2Pulse.instant());
         mapService.setDbInitialized(false);
     }

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/MapStatsFilmIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/MapStatsFilmIT.java
@@ -12,9 +12,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.BaseMatch;
@@ -34,7 +34,6 @@ import com.nephest.battlenet.sc2.model.local.dao.PopulationStateDAO;
 import com.nephest.battlenet.sc2.model.local.dao.TeamDAO;
 import com.nephest.battlenet.sc2.model.local.dao.TeamStateDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderMapStatsFilm;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.service.EventService;
 import java.time.Instant;
@@ -48,7 +47,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,6 +67,7 @@ import reactor.core.Disposable;
 @SpringBootTest(classes = AllTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class MapStatsFilmIT
 {
 
@@ -118,10 +117,9 @@ public class MapStatsFilmIT
     private JdbcTemplate jdbcTemplate;
 
     @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
+    public void beforeEach()
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         mapService.getMapStatsInstant().setValue(SC2Pulse.instant());
         mapService.setDbInitialized(false);
     }
@@ -129,13 +127,10 @@ public class MapStatsFilmIT
     @AfterAll
     public static void afterAll
     (
-        @Autowired DataSource dataSource,
-        @Autowired MapService mapService,
-        @Autowired Client clickHouseClient
+        @Autowired MapService mapService
     )
     throws Exception
     {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
         mapService.getMapStatsInstant().setValue(SC2Pulse.instant());
         mapService.setDbInitialized(false);
     }

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/MapStatsFilmRaceFilterIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/MapStatsFilmRaceFilterIT.java
@@ -10,9 +10,9 @@ import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -29,13 +29,11 @@ import com.nephest.battlenet.sc2.model.local.dao.PopulationStateDAO;
 import com.nephest.battlenet.sc2.model.local.dao.TeamDAO;
 import com.nephest.battlenet.sc2.model.local.dao.TeamStateDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderMapStatsFilm;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.service.EventService;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -55,6 +53,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = AllTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class MapStatsFilmRaceFilterIT
 {
 
@@ -70,7 +69,6 @@ public class MapStatsFilmRaceFilterIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
         @Autowired MapService mapService,
         @Autowired SeasonGenerator seasonGenerator,
         @Autowired LeagueStatsDAO leagueStatsDAO,
@@ -81,12 +79,10 @@ public class MapStatsFilmRaceFilterIT
         @Autowired MatchDAO matchDAO,
         @Autowired MatchParticipantDAO matchParticipantDAO,
         @Autowired EventService eventService,
-        @Autowired MapStatsFilmTestService mapStatsFilmTestService,
-        @Autowired Client clickHouseClient
+        @Autowired MapStatsFilmTestService mapStatsFilmTestService
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         mapService.getMapStatsInstant().setValue(SC2Pulse.instant());
         mapService.setDbInitialized(false);
         mapStatsFilmTestService.generateFilms((startFrom)->{
@@ -103,13 +99,10 @@ public class MapStatsFilmRaceFilterIT
     @AfterAll
     public static void afterAll
     (
-        @Autowired DataSource dataSource,
-        @Autowired MapService mapService,
-        @Autowired Client clickHouseClient
+        @Autowired MapService mapService
     )
     throws Exception
     {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
         mapService.getMapStatsInstant().setValue(SC2Pulse.instant());
         mapService.setDbInitialized(false);
     }

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/MatchIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/MatchIT.java
@@ -9,10 +9,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.BaseMatch;
@@ -60,7 +60,6 @@ import com.nephest.battlenet.sc2.model.local.ladder.LadderMatchParticipant;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderMatchDAO;
 import com.nephest.battlenet.sc2.model.navigation.Cursor;
 import com.nephest.battlenet.sc2.model.navigation.NavigationDirection;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.model.validation.CursorNavigableResult;
 import java.time.Duration;
@@ -71,10 +70,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -91,6 +87,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = {AllTestConfig.class})
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class MatchIT
 {
 
@@ -160,20 +157,6 @@ public class MatchIT
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @BeforeEach
-    public void beforeAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterEach
-    public void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     /*TODO
         Split this abomination into proper tests

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/MatchServiceIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/MatchServiceIT.java
@@ -11,22 +11,18 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.security.SC2PulseAuthority;
 import com.nephest.battlenet.sc2.config.security.WithBlizzardMockUser;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.blizzard.BlizzardTest;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.service.EventService;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -44,6 +40,7 @@ import org.springframework.web.context.WebApplicationContext;
 @BlizzardTest
 @SpringBootTest(classes = {AllTestConfig.class})
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class MatchServiceIT
 {
 
@@ -61,36 +58,12 @@ public class MatchServiceIT
     @Autowired
     private GlobalContext globalContext;
 
-    @BeforeAll
-    public static void beforeAll
-    (
-        @Autowired BlizzardSC2API api,
-        @Autowired DataSource dataSource,
-        @Autowired Client clickHouseClient
-    )
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
     @BeforeEach
     public void beforeEach()
     {
         matchService.getUpdateMatchesTask()
             .setValue(SC2Pulse.instant().minus(MatchService.MATCH_UPDATE_FRAME));
         matchService.setUpdateContext(null);
-    }
-
-    @AfterAll
-    public static void afterAll
-    (
-        @Autowired BlizzardSC2API api,
-        @Autowired DataSource dataSource,
-        @Autowired Client clickHouseClient
-    )
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     /*TODO

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/MvcIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/MvcIT.java
@@ -14,16 +14,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.filter.NoCacheFilter;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -42,6 +38,7 @@ import org.springframework.util.DigestUtils;
 @SpringBootTest(classes = AllTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class MvcIT
 {
 
@@ -53,20 +50,6 @@ public class MvcIT
 
     @Value("${com.nephest.battlenet.sc2.cors.allowed-origin-patterns:#{''}}")
     private List<String> corsAllowedOriginPatterns;
-
-    @BeforeAll
-    public static void beforeAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @CsvSource
     ({

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/PlayerCharacterStatsIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/PlayerCharacterStatsIT.java
@@ -6,10 +6,10 @@ package com.nephest.battlenet.sc2.web.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.Partition;
@@ -36,7 +36,6 @@ import com.nephest.battlenet.sc2.model.local.dao.TeamStateDAO;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyId;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderPlayerCharacterStats;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderPlayerCharacterStatsDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.util.Collection;
 import java.util.List;
@@ -44,9 +43,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -57,6 +53,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = AllTestConfig.class)
 @TestPropertySource("classpath:application.properties")
 @AutoConfigureMockMvc
+@AutoConfigureDatabase
 public class PlayerCharacterStatsIT
 {
 
@@ -99,20 +96,6 @@ public class PlayerCharacterStatsIT
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterEach
-    public void afterEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testGlobalStatsCalculation()

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/ProPlayerServiceIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/ProPlayerServiceIT.java
@@ -9,9 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -35,7 +35,6 @@ import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderCharacterDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderProPlayerDAO;
 import com.nephest.battlenet.sc2.model.revealed.RevealedPlayers;
 import com.nephest.battlenet.sc2.model.revealed.RevealedProPlayer;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.twitch.TwitchTest;
 import java.io.IOException;
@@ -50,13 +49,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.sql.DataSource;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -67,6 +63,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @SpringBootTest(classes = AllTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class ProPlayerServiceIT
 {
 
@@ -106,19 +103,6 @@ public class ProPlayerServiceIT
 
     private static Set<SocialMedia> SOCIAL_MEDIA_SERVICES;
 
-    @BeforeEach
-    public void beforeEach
-    (
-        @Autowired DataSource dataSource,
-        @Autowired SeasonGenerator seasonGenerator,
-        @Autowired PlayerCharacterStatsDAO playerCharacterStatsDAO,
-        @Autowired Client clickHouseClient
-    )
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
     @BeforeAll
     public static void beforeAll(@Autowired Environment environment)
     {
@@ -126,13 +110,6 @@ public class ProPlayerServiceIT
             .map(SocialMedia::from)
             .filter(sm->sm != SocialMedia.UNKNOWN)
             .collect(Collectors.toSet());
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test @SuppressWarnings("deprecation")

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/RecentTeamIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/RecentTeamIT.java
@@ -10,10 +10,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -22,14 +22,11 @@ import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.TeamType;
 import com.nephest.battlenet.sc2.model.local.SeasonGenerator;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderTeam;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.web.controller.TeamController;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -48,6 +45,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = AllTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class RecentTeamIT
 {
 
@@ -67,11 +65,9 @@ public class RecentTeamIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
         @Autowired JdbcTemplate jdbc,
         @Autowired SeasonGenerator seasonGenerator,
-        @Autowired @Qualifier("mvcConversionService") ConversionService cs,
-        @Autowired Client clickHouseClient
+        @Autowired @Qualifier("mvcConversionService") ConversionService cs
     )
     throws Exception
     {
@@ -80,7 +76,6 @@ public class RecentTeamIT
         urlStart1v1 = "/api/teams?queue=" + cs.convert(QueueType.LOTV_1V1, String.class)
             + "&league=" + cs.convert(BaseLeague.LeagueType.GOLD, String.class)
             + "&recent=true";
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         seasonGenerator.generateDefaultSeason
         (
             List.of(Region.EU, Region.US),
@@ -98,13 +93,6 @@ public class RecentTeamIT
         );
         jdbc.update("UPDATE team SET wins = id");
         jdbc.update("UPDATE team SET rating = wins * 2");
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     public static Stream<Arguments> testFindRecentTeams()

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/RevealControllerIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/RevealControllerIT.java
@@ -17,11 +17,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.security.SC2PulseAuthority;
 import com.nephest.battlenet.sc2.config.security.WithBlizzardMockUser;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.Partition;
@@ -43,7 +43,6 @@ import com.nephest.battlenet.sc2.model.local.dao.ProPlayerDAO;
 import com.nephest.battlenet.sc2.model.local.dao.SocialMediaLinkDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderProPlayer;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderProPlayerDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.twitch.TwitchTest;
 import java.time.LocalDate;
@@ -53,7 +52,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -71,6 +69,7 @@ import reactor.core.publisher.Mono;
 
 @SpringBootTest(classes = AllTestConfig.class)
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class RevealControllerIT
 {
 
@@ -119,13 +118,10 @@ public class RevealControllerIT
     @BeforeEach
     public void beforeEach
     (
-        @Autowired DataSource dataSource,
-        @Autowired WebApplicationContext webApplicationContext,
-        @Autowired Client clickHouseClient
+        @Autowired WebApplicationContext webApplicationContext
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         mvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).apply(springSecurity())
             .alwaysDo(print()).build();
         mockApi = mock(AligulacAPI.class);
@@ -133,10 +129,9 @@ public class RevealControllerIT
     }
 
     @AfterEach
-    public void afterEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
+    public void afterEach()
     throws Exception
     {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
         proPlayerService.setAligulacAPI(realApi);
     }
 

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/RevealerAuditLogIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/RevealerAuditLogIT.java
@@ -13,7 +13,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
@@ -21,6 +20,7 @@ import com.nephest.battlenet.sc2.config.security.AccountSecurityContextFactory;
 import com.nephest.battlenet.sc2.config.security.AccountUser;
 import com.nephest.battlenet.sc2.config.security.SC2PulseAuthority;
 import com.nephest.battlenet.sc2.config.security.WithBlizzardMockUser;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.Partition;
@@ -32,14 +32,11 @@ import com.nephest.battlenet.sc2.model.local.AuditLogEntry;
 import com.nephest.battlenet.sc2.model.local.ProPlayer;
 import com.nephest.battlenet.sc2.model.local.SeasonGenerator;
 import com.nephest.battlenet.sc2.model.local.dao.ProPlayerDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.model.validation.CursorNavigableResult;
 import java.time.OffsetDateTime;
 import java.util.List;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,6 +54,7 @@ import org.springframework.web.context.WebApplicationContext;
 @SpringBootTest(classes = AllTestConfig.class)
 @TestPropertySource("classpath:application.properties")
 @AutoConfigureMockMvc
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class RevealerAuditLogIT
 {
 
@@ -99,16 +97,13 @@ public class RevealerAuditLogIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
         @Autowired WebApplicationContext webApplicationContext,
         @Autowired SeasonGenerator generator,
         @Autowired ProPlayerDAO proPlayerDAO,
-        @Autowired AccountSecurityContextFactory accountSecurityContextFactory,
-        @Autowired Client clickHouseClient
+        @Autowired AccountSecurityContextFactory accountSecurityContextFactory
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         MockMvc mvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
             .apply(springSecurity())
             .alwaysDo(print())
@@ -152,13 +147,6 @@ public class RevealerAuditLogIT
             .andReturn();
     }
 
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     @WithBlizzardMockUser

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/SC2ArcadeAPIIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/SC2ArcadeAPIIT.java
@@ -6,14 +6,12 @@ package com.nephest.battlenet.sc2.web.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.PlayerCharacterNaturalId;
 import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.arcade.ArcadePlayerCharacter;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import java.io.IOException;
-import javax.sql.DataSource;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -25,6 +23,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @SpringBootTest(classes = {AllTestConfig.class})
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class SC2ArcadeAPIIT
 {
 
@@ -36,27 +35,21 @@ public class SC2ArcadeAPIIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired SC2ArcadeAPI api,
-        @Autowired DataSource dataSource,
-        @Autowired Client clickHouseClient
+        @Autowired SC2ArcadeAPI api
     )
     throws Exception
     {
         originalClient = WebServiceTestUtil.fastTimers(api);
-        DbTestUtil.initDb(dataSource, clickHouseClient);
     }
 
     @AfterAll
     public static void afterAll
     (
-        @Autowired SC2ArcadeAPI api,
-        @Autowired DataSource dataSource,
-        @Autowired Client clickHouseClient
+        @Autowired SC2ArcadeAPI api
     )
     throws Exception
     {
         WebServiceTestUtil.revertFastTimers(api, originalClient);
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/SC2MetaServiceIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/SC2MetaServiceIT.java
@@ -7,24 +7,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.local.dao.PatchDAO;
 import com.nephest.battlenet.sc2.model.local.dao.PatchReleaseDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderPatch;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.web.service.liquipedia.LiquipediaAPI;
 import java.time.OffsetDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -36,6 +32,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = AllTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class SC2MetaServiceIT
 {
 
@@ -56,20 +53,6 @@ public class SC2MetaServiceIT
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testPatch()

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/SC2ReplayStatsAPIIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/SC2ReplayStatsAPIIT.java
@@ -6,16 +6,14 @@ package com.nephest.battlenet.sc2.web.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.PlayerCharacterNaturalId;
 import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.replaystats.ReplayStatsPlayerCharacter;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.util.TestUtil;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import javax.sql.DataSource;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,6 +32,7 @@ import org.springframework.web.reactive.function.client.WebClient;
     reason = "Authorization token not found",
     loadContext = true
 )
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class SC2ReplayStatsAPIIT
 {
 
@@ -64,27 +63,21 @@ public class SC2ReplayStatsAPIIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired SC2ReplayStatsAPI api,
-        @Autowired DataSource dataSource,
-        @Autowired Client clickHouseClient
+        @Autowired SC2ReplayStatsAPI api
     )
     throws Exception
     {
         originalClient = WebServiceTestUtil.fastTimers(api);
-        DbTestUtil.initDb(dataSource, clickHouseClient);
     }
 
     @AfterAll
     public static void afterAll
     (
-        @Autowired SC2ReplayStatsAPI api,
-        @Autowired DataSource dataSource,
-        @Autowired Client clickHouseClient
+        @Autowired SC2ReplayStatsAPI api
     )
     throws Exception
     {
         WebServiceTestUtil.revertFastTimers(api, originalClient);
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/SearchServiceIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/SearchServiceIT.java
@@ -9,9 +9,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BasePlayerCharacter;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.Region;
@@ -21,11 +21,8 @@ import com.nephest.battlenet.sc2.model.local.PlayerCharacter;
 import com.nephest.battlenet.sc2.model.local.dao.AccountDAO;
 import com.nephest.battlenet.sc2.model.local.dao.ClanDAO;
 import com.nephest.battlenet.sc2.model.local.dao.PlayerCharacterDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.web.controller.CharacterController;
 import java.util.Set;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +38,7 @@ import org.springframework.web.context.WebApplicationContext;
 @SpringBootTest(classes = AllTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class SearchServiceIT
 {
 
@@ -53,17 +51,14 @@ public class SearchServiceIT
     @BeforeAll
     public static void init
     (
-        @Autowired DataSource dataSource,
         @Autowired WebApplicationContext webApplicationContext,
         @Autowired AccountDAO accountDAO,
         @Autowired PlayerCharacterDAO playerCharacterDAO,
         @Autowired ClanDAO clanDAO,
-        @Autowired JdbcTemplate template,
-        @Autowired Client clickHouseClient
+        @Autowired JdbcTemplate template
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         for(int i = 0; i < CharacterController.SEARCH_SUGGESTIONS_SIZE + 1; i++)
             accountDAO.merge(new Account(null, Partition.GLOBAL, "ab#" + i));
         accountDAO.merge(new Account(null, Partition.GLOBAL, "aa#1"));
@@ -99,13 +94,6 @@ public class SearchServiceIT
             clanDAO.merge(Set.of(new Clan(null, "a" + Character.toString('a' + i), Region.EU, null)));
         clanDAO.merge(Set.of(new Clan(null, "b" + Character.toString('a' + (int) bIx), Region.EU, null)));
         template.update("UPDATE clan SET active_members = id");
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     private String[] getSuggestions(String query)

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/SeasonServiceIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/SeasonServiceIT.java
@@ -11,23 +11,19 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.SpyBeanConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Region;
 import com.nephest.battlenet.sc2.model.local.Season;
 import com.nephest.battlenet.sc2.model.local.dao.SeasonDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.web.SeasonService;
 import java.time.OffsetDateTime;
 import java.util.List;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -39,6 +35,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = {AllTestConfig.class, SpyBeanConfig.class})
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class SeasonServiceIT
 {
 
@@ -53,20 +50,6 @@ public class SeasonServiceIT
 
     @Autowired
     private SeasonDAO seasonDAO;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void whenNewSeasonIsInsertedOrUpdated_thenSetPreviousSeasonEndDateToNewStartDate()

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/SecurityIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/SecurityIT.java
@@ -1,18 +1,15 @@
-// Copyright (C) 2020-2025 Oleksandr Masniuk
+// Copyright (C) 2020-2026 Oleksandr Masniuk
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 package com.nephest.battlenet.sc2.web.service;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.security.SC2PulseAuthority;
 import com.nephest.battlenet.sc2.config.security.WithBlizzardMockUser;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.local.Account;
 import com.nephest.battlenet.sc2.model.local.dao.AccountDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -28,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @ActiveProfiles({"default", "prod", "test"})
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class SecurityIT
 {
 
@@ -37,22 +35,11 @@ public class SecurityIT
     @BeforeAll
     public static void init
     (
-        @Autowired DataSource dataSource,
-        @Autowired AccountDAO accountDAO,
-        @Autowired Client clickHouseClient
+        @Autowired AccountDAO accountDAO
     ) throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         accountDAO.merge(new Account(1L, Partition.GLOBAL, "user"));
     }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
-
 
     @ParameterizedTest
     @CsvSource

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/StatsServiceIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/StatsServiceIT.java
@@ -17,10 +17,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.security.SC2PulseAuthority;
 import com.nephest.battlenet.sc2.config.security.WithBlizzardMockUser;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -45,14 +45,11 @@ import com.nephest.battlenet.sc2.model.local.Season;
 import com.nephest.battlenet.sc2.model.local.dao.FastTeamDAO;
 import com.nephest.battlenet.sc2.model.local.dao.SeasonDAO;
 import com.nephest.battlenet.sc2.model.local.dao.TeamDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigInteger;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -71,6 +68,7 @@ import org.springframework.web.context.WebApplicationContext;
 @SpringBootTest(classes = {AllTestConfig.class})
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class StatsServiceIT
 {
 
@@ -93,14 +91,11 @@ public class StatsServiceIT
     @BeforeEach
     public void beforeEach
     (
-        @Autowired DataSource dataSource,
         @Autowired WebApplicationContext webApplicationContext,
-        @Autowired Validator validator,
-        @Autowired Client clickHouseClient
+        @Autowired Validator validator
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         teamDAO = mock(TeamDAO.class);
         fastTeamDAO = mock(FastTeamDAO.class);
         statsService = new StatsService
@@ -133,13 +128,6 @@ public class StatsServiceIT
         );
         StatsService nss = mock(StatsService.class);
         statsService.setNestedService(nss);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/SupportersServiceIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/SupportersServiceIT.java
@@ -12,14 +12,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.security.SC2PulseAuthority;
 import com.nephest.battlenet.sc2.config.security.WithBlizzardMockUser;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +29,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(classes = {AllTestConfig.class})
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class SupportersServiceIT
 {
 
@@ -43,25 +41,15 @@ public class SupportersServiceIT
     @BeforeAll
     public static void init
     (
-        @Autowired DataSource dataSource,
-        @Autowired WebApplicationContext webApplicationContext,
-        @Autowired Client clickHouseClient
+        @Autowired WebApplicationContext webApplicationContext
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         mvc = MockMvcBuilders
             .webAppContextSetup(webApplicationContext)
             .apply(springSecurity())
             .alwaysDo(print())
             .build();
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/TeamGroupHistoryCornerCaseIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/TeamGroupHistoryCornerCaseIT.java
@@ -11,10 +11,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -34,7 +34,6 @@ import com.nephest.battlenet.sc2.model.local.inner.TeamHistoryDAO;
 import com.nephest.battlenet.sc2.model.local.inner.TeamHistorySummary;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyUid;
 import com.nephest.battlenet.sc2.model.util.ClickHouseUtil;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.util.AssertionUtil;
 import java.time.OffsetDateTime;
@@ -45,10 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -63,6 +59,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = AllTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class TeamGroupHistoryCornerCaseIT
 {
 
@@ -95,20 +92,6 @@ public class TeamGroupHistoryCornerCaseIT
 
     @Autowired
     private SeasonGenerator seasonGenerator;
-
-    @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void whenTeamSnapshotsOverstepCurrentSeasonBoundaries_thenIgnoreBoundaries()

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/TeamGroupHistoryIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/TeamGroupHistoryIT.java
@@ -10,10 +10,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -46,7 +46,6 @@ import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyUid;
 import com.nephest.battlenet.sc2.model.local.inner.TypedTeamHistoryHistoryData;
 import com.nephest.battlenet.sc2.model.local.inner.TypedTeamHistoryStaticData;
 import com.nephest.battlenet.sc2.model.local.inner.TypedTeamHistorySummaryData;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.model.validation.UInt32EpochSecondsTemporalAccessorValidatorSimpleIntegrationTest;
 import com.nephest.battlenet.sc2.util.AssertionUtil;
@@ -69,10 +68,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -95,6 +92,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class TeamGroupHistoryIT
 {
 
@@ -128,8 +126,6 @@ public class TeamGroupHistoryIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
-        @Autowired Client clickHouseCLient,
         @Autowired DivisionDAO divisionDAO,
         @Autowired TeamDAO teamDAO,
         @Autowired TeamStateDAO teamStateDAO,
@@ -142,7 +138,6 @@ public class TeamGroupHistoryIT
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseCLient);
         teamLegacyUid = new TeamLegacyUid
         (
             QueueType.LOTV_1V1,
@@ -163,13 +158,6 @@ public class TeamGroupHistoryIT
             jdbcTemplate,
             mvcConversionService
         );
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     private static void init

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/TeamGroupIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/TeamGroupIT.java
@@ -8,10 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.IdField;
@@ -36,7 +36,6 @@ import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyIdEntry;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyUid;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderTeam;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderTeamMember;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.web.controller.group.TeamGroupArgumentResolver;
 import com.nephest.battlenet.sc2.web.util.TeamLegacyUidValidationUtil;
@@ -51,9 +50,7 @@ import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -71,6 +68,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(classes = AllTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class TeamGroupIT
 {
 
@@ -87,18 +85,15 @@ public class TeamGroupIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
         @Autowired TeamDAO teamDAO,
         @Autowired TeamMemberDAO teamMemberDAO,
         @Autowired PopulationStateDAO populationStateDAO,
         @Autowired LeagueStatsDAO leagueStatsDAO,
         @Autowired SeasonGenerator seasonGenerator,
-        @Autowired @Qualifier("mvcConversionService") ConversionService conversionService,
-        @Autowired Client clickHouseClient
+        @Autowired @Qualifier("mvcConversionService") ConversionService conversionService
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         init(teamDAO, teamMemberDAO, populationStateDAO, leagueStatsDAO, seasonGenerator);
         TeamGroupIT.conversionService = conversionService;
     }
@@ -204,13 +199,6 @@ public class TeamGroupIT
         leagueStatsDAO.mergeCalculateForSeason(statsSeason);
         populationStateDAO.takeSnapshot(List.of(statsSeason));
         teamDAO.updateRanks(statsSeason);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     public static LadderTeam fromId(Long id)

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/TeamStateServiceIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/TeamStateServiceIT.java
@@ -19,11 +19,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.SpyBeanConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.QueueType;
@@ -41,8 +41,8 @@ import com.nephest.battlenet.sc2.model.local.inner.RawTeamHistoryStaticData;
 import com.nephest.battlenet.sc2.model.local.inner.TeamHistory;
 import com.nephest.battlenet.sc2.model.local.inner.TeamHistoryDAO;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyId;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
+import com.nephest.battlenet.sc2.model.util.TestDatabaseLifecycleService;
 import com.nephest.battlenet.sc2.service.EventService;
 import com.nephest.battlenet.sc2.util.AssertionUtil;
 import java.time.Instant;
@@ -56,7 +56,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -80,6 +79,7 @@ import reactor.core.scheduler.Schedulers;
 @SpringBootTest(classes = {AllTestConfig.class, SpyBeanConfig.class})
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class TeamStateServiceIT
 {
 
@@ -130,10 +130,9 @@ public class TeamStateServiceIT
     private static int secondaryLengthBefore;
 
     @BeforeEach
-    public void beforeEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
+    public void beforeEach()
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         teamStateService.reset();
         updateService.updated(Instant.MIN);
         mainLengthBefore = teamStateService.getMainLengthDays();
@@ -154,14 +153,20 @@ public class TeamStateServiceIT
     @AfterAll
     public static void afterAll
     (
-        @Autowired DataSource dataSource,
-        @Autowired Client clickHouseClient,
+        @Autowired TestDatabaseLifecycleService lifecycleService,
         @Autowired TeamStateService teamStateService
     )
     throws Exception
     {
-        teamStateService.reset();
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
+        try
+        {
+            lifecycleService.initDb();
+            teamStateService.reset();
+        }
+        finally
+        {
+            lifecycleService.clearDb();
+        }
     }
 
     private static LadderUpdateData createUpdateData(int season)

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/TwitchAPIIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/TwitchAPIIT.java
@@ -7,12 +7,11 @@ import static com.nephest.battlenet.sc2.web.service.community.TwitchVideoStreamS
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.clickhouse.client.api.Client;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.twitch.dto.TwitchStreamDto;
 import com.nephest.battlenet.sc2.model.twitch.dto.TwitchUserDto;
 import com.nephest.battlenet.sc2.model.twitch.dto.TwitchVideoDto;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.twitch.TwitchTest;
 import java.util.List;
 import java.util.Set;
@@ -20,8 +19,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,6 +32,7 @@ import reactor.core.publisher.Flux;
 @TwitchTest
 @SpringBootTest(classes = {AllTestConfig.class})
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class TwitchAPIIT
 {
 
@@ -43,25 +41,11 @@ public class TwitchAPIIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
-        @Autowired TwitchAPI api,
-        @Autowired Client clickHouseClient
+        @Autowired TwitchAPI api
     )
     throws Exception
     {
         TwitchAPIIT.api = api;
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll
-    (
-        @Autowired DataSource dataSource,
-        @Autowired Client clickHouseClient
-    )
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     public static Stream<Arguments> whenExceedingMaxUserBatchSize_thenSplitRequestOnSubBatches()

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/VersusIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/VersusIT.java
@@ -10,10 +10,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.BaseMatch;
@@ -54,15 +54,12 @@ import com.nephest.battlenet.sc2.model.local.ladder.LadderMatch;
 import com.nephest.battlenet.sc2.model.local.ladder.PagedSearchResult;
 import com.nephest.battlenet.sc2.model.local.ladder.Versus;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderMatchDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import java.time.OffsetDateTime;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -79,6 +76,7 @@ import reactor.util.function.Tuples;
 
 @SpringBootTest(classes = {AllTestConfig.class})
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase(AutoConfigureDatabase.ExecutionPhase.CLASS)
 public class VersusIT
 {
 
@@ -136,7 +134,6 @@ public class VersusIT
     @BeforeAll
     public static void beforeAll
     (
-        @Autowired DataSource dataSource,
         @Autowired SeasonGenerator seasonGenerator,
         @Autowired DivisionDAO divisionDAO,
         @Autowired ClanDAO clanDAO,
@@ -149,12 +146,10 @@ public class VersusIT
         @Autowired MatchParticipantDAO matchParticipantDAO,
         @Autowired TeamStateDAO teamStateDAO,
         @Autowired SC2MapDAO mapDAO,
-        @Autowired WebApplicationContext webApplicationContext,
-        @Autowired Client clickHouseClient
+        @Autowired WebApplicationContext webApplicationContext
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         mvc = MockMvcBuilders
             .webAppContextSetup(webApplicationContext)
             .apply(springSecurity())
@@ -259,13 +254,6 @@ public class VersusIT
         ));
 
         matchParticipantDAO.identify(SeasonGenerator.DEFAULT_SEASON_ID, OffsetDateTime.MIN);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     private static Team createTeam(TeamDAO teamDAO, PlayerCharacter character, Division division)

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/community/CommunityVideoStreamIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/community/CommunityVideoStreamIT.java
@@ -16,10 +16,10 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.QueueType;
 import com.nephest.battlenet.sc2.model.Race;
@@ -44,7 +44,6 @@ import com.nephest.battlenet.sc2.model.local.dao.TeamDAO;
 import com.nephest.battlenet.sc2.model.local.dao.TeamMemberDAO;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderProPlayer;
 import com.nephest.battlenet.sc2.model.local.ladder.dao.LadderSearchDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.model.web.SortParameter;
 import com.nephest.battlenet.sc2.util.wrapper.ThreadLocalRandomSupplier;
@@ -65,7 +64,6 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -91,6 +89,7 @@ import reactor.core.publisher.Flux;
 @SpringBootTest(classes = {CommunityVideoStreamIT.InitConfiguration.class, AllTestConfig.class})
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class CommunityVideoStreamIT
 {
 
@@ -176,13 +175,10 @@ public class CommunityVideoStreamIT
     @BeforeEach
     public void beforeEach
     (
-        @Autowired DataSource dataSource,
-        @Autowired(required = false) TwitchVideoStreamSupplier twitchVideoStreamSupplier,
-        @Autowired Client clickHouseClient
+        @Autowired(required = false) TwitchVideoStreamSupplier twitchVideoStreamSupplier
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         when(otherStreamSupplier.getStreams()).thenReturn(Flux.empty());
         if(twitchVideoStreamSupplier != null)
             when(twitchVideoStreamSupplier.getStreams()).thenReturn(Flux.empty());
@@ -239,13 +235,6 @@ public class CommunityVideoStreamIT
             .map(i->new ProPlayerAccount(proPlayers[i].getId(), accounts[i].getId()))
             .collect(Collectors.toSet())
         );
-    }
-
-    @AfterEach
-    public void afterEach(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @AfterEach

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/external/ExternalServiceIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/external/ExternalServiceIT.java
@@ -14,10 +14,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.config.SpyBeanConfig;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.BaseLeague;
 import com.nephest.battlenet.sc2.model.BaseLeagueTier;
 import com.nephest.battlenet.sc2.model.Partition;
@@ -39,7 +39,6 @@ import com.nephest.battlenet.sc2.model.local.dao.PlayerCharacterLinkDAO;
 import com.nephest.battlenet.sc2.model.local.dao.PlayerCharacterStatsDAO;
 import com.nephest.battlenet.sc2.model.local.inner.TeamLegacyId;
 import com.nephest.battlenet.sc2.model.local.ladder.LadderDistinctCharacter;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.model.util.SC2Pulse;
 import com.nephest.battlenet.sc2.web.service.SC2ArcadeAPI;
 import java.util.Arrays;
@@ -49,9 +48,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,6 +73,7 @@ import reactor.core.publisher.Mono;
 
 @SpringBootTest(classes = {AllTestConfig.class, SpyBeanConfig.class})
 @TestPropertySource("classpath:application.properties")
+@AutoConfigureDatabase
 public class ExternalServiceIT
 {
 
@@ -133,13 +131,10 @@ public class ExternalServiceIT
     @BeforeEach
     public void beforeEach
     (
-        @Autowired DataSource dataSource,
-        @Autowired WebApplicationContext webApplicationContext,
-        @Autowired Client clickHouseClient
+        @Autowired WebApplicationContext webApplicationContext
     )
     throws Exception
     {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
         mvc = MockMvcBuilders
             .webAppContextSetup(webApplicationContext)
             .apply(springSecurity())
@@ -239,13 +234,6 @@ public class ExternalServiceIT
                 Set.of()
             )
         };
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
     }
 
     @Test

--- a/src/test/java/com/nephest/battlenet/sc2/web/service/linked/LinkedServiceIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/web/service/linked/LinkedServiceIT.java
@@ -6,27 +6,23 @@ package com.nephest.battlenet.sc2.web.service.linked;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.clickhouse.client.api.Client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nephest.battlenet.sc2.config.AllTestConfig;
 import com.nephest.battlenet.sc2.discord.DiscordTest;
+import com.nephest.battlenet.sc2.extension.AutoConfigureDatabase;
 import com.nephest.battlenet.sc2.model.Partition;
 import com.nephest.battlenet.sc2.model.SocialMedia;
 import com.nephest.battlenet.sc2.model.discord.DiscordUser;
 import com.nephest.battlenet.sc2.model.discord.dao.DiscordUserDAO;
 import com.nephest.battlenet.sc2.model.local.Account;
 import com.nephest.battlenet.sc2.model.local.dao.AccountDAO;
-import com.nephest.battlenet.sc2.model.util.DbTestUtil;
 import com.nephest.battlenet.sc2.web.service.DiscordService;
 import com.nephest.battlenet.sc2.web.service.WebServiceTestUtil;
 import discord4j.common.util.Snowflake;
 import java.util.Map;
 import java.util.Set;
-import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -34,12 +30,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.context.WebApplicationContext;
 
 @DiscordTest
 @SpringBootTest(classes = {AllTestConfig.class})
 @TestPropertySource("classpath:application.properties")
 @AutoConfigureMockMvc
+@AutoConfigureDatabase
 public class LinkedServiceIT
 {
 
@@ -57,25 +53,6 @@ public class LinkedServiceIT
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @BeforeEach
-    public void beforeEach
-    (
-        @Autowired DataSource dataSource,
-        @Autowired WebApplicationContext webApplicationContext,
-        @Autowired Client clickHouseClient
-    )
-    throws Exception
-    {
-        DbTestUtil.initDb(dataSource, clickHouseClient);
-    }
-
-    @AfterAll
-    public static void afterAll(@Autowired DataSource dataSource, @Autowired Client clickHouseClient)
-    throws Exception
-    {
-        DbTestUtil.clearDb(dataSource, clickHouseClient);
-    }
 
     @Test
     public void testGetLinkedAccounts()


### PR DESCRIPTION
## Summary
- Add `TestDatabaseLifecycleService`: Spring-managed service replacing the static `DbTestUtil.initDb/clearDb` calls
- Add `DatabaseLifecycleExtension` + `@AutoConfigureDatabase` annotation with `ExecutionPhase` (`CLASS`/`METHOD`) to centralize DB lifecycle in a JUnit extension
- Migrate all 84 integration tests to use `@AutoConfigureDatabase`, removing manual `DataSource`/`Client` wiring and lifecycle boilerplate

## Test plan
- [x] `mvn verify -Dit.test=!GeneralSeleniumIT` — 1366 tests pass
- [x] `mvn verify -Dit.test=GeneralSeleniumIT` — 16 tests pass (2 skipped)

closes #709