### PR TITLE
anonymize reporter account data for regular users

### DIFF
--- a/src/main/java/com/nephest/battlenet/sc2/model/local/ladder/LadderEvidence.java
+++ b/src/main/java/com/nephest/battlenet/sc2/model/local/ladder/LadderEvidence.java
@@ -17,7 +17,7 @@ public class LadderEvidence
     @NotNull
     private final List<LadderEvidenceVote> votes;
 
-    private final Account reporterAccount;
+    private Account reporterAccount;
 
     public LadderEvidence(Evidence evidence, List<LadderEvidenceVote> votes, Account reporterAccount)
     {
@@ -39,6 +39,11 @@ public class LadderEvidence
     public Account getReporterAccount()
     {
         return reporterAccount;
+    }
+
+    public void setReporterAccount(Account reporterAccount)
+    {
+        this.reporterAccount = reporterAccount;
     }
 
 }

--- a/src/main/java/com/nephest/battlenet/sc2/web/service/PlayerCharacterReportService.java
+++ b/src/main/java/com/nephest/battlenet/sc2/web/service/PlayerCharacterReportService.java
@@ -218,10 +218,15 @@ public class PlayerCharacterReportService
         reports.stream()
             .map(LadderPlayerCharacterReport::getEvidence)
             .flatMap(Collection::stream)
-            .map(LadderEvidence::getVotes)
-            .flatMap(Collection::stream)
             .forEach(PlayerCharacterReportService::clearSensitiveData);
         return reports;
+    }
+
+    public static void clearSensitiveData(LadderEvidence evidence)
+    {
+        evidence.getEvidence().setReporterAccountId(null);
+        evidence.setReporterAccount(null);
+        evidence.getVotes().forEach(PlayerCharacterReportService::clearSensitiveData);
     }
 
     public static void clearSensitiveData(LadderEvidenceVote vote)

--- a/src/main/resources/templates/fragments/app.html
+++ b/src/main/resources/templates/fragments/app.html
@@ -111,7 +111,7 @@
                     <div id="report-character-menu">
                         <div>
                             Your report will be reviewed by moderators.
-                            <strong class="text-danger">Your BattleTag and confirmed reports will be publicly visible.</strong>
+                            <strong class="text-danger">Confirmed reports will be publicly visible.</strong>
                             Moderators:
                             <span th:text="${#strings.listJoin(@userController.getModTags(), ', ')}"></span>
                         </div>

--- a/src/test/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterReportIT.java
+++ b/src/test/java/com/nephest/battlenet/sc2/model/local/dao/PlayerCharacterReportIT.java
@@ -979,20 +979,25 @@ public class PlayerCharacterReportIT
 
         evidenceVoteDAO.merge(new EvidenceVote(1, SC2Pulse.offsetDateTime(), 10L, true, SC2Pulse.offsetDateTime()));
         setReportAndEvidenceStatus(PlayerCharacterReport.Status.CONFIRMED);
-        LadderEvidenceVote voteAll = getReports()[0].getEvidence().get(0).getVotes().get(0);
+        LadderEvidence evidenceAll = getReports()[0].getEvidence().get(0);
+        LadderEvidenceVote voteAll = evidenceAll.getVotes().get(0);
         assertNull(voteAll.getVoterAccount());
         assertNull(voteAll.getVote().getVoterAccountId());
+        assertNull(evidenceAll.getReporterAccount());
+        assertNull(evidenceAll.getEvidence().getReporterAccountId());
 
-        LadderEvidenceVote voteById = WebServiceTestUtil.getObject
+        LadderEvidence evidenceById = WebServiceTestUtil.getObject
         (
             mvc, objectMapper, LadderPlayerCharacterReport[].class,
             "/api/character/report/list/5"
         )
             [0]
-            .getEvidence().get(0)
-            .getVotes().get(0);
+            .getEvidence().get(0);
+        LadderEvidenceVote voteById = evidenceById.getVotes().get(0);
         assertNull(voteById.getVoterAccount());
         assertNull(voteById.getVote().getVoterAccountId());
+        assertNull(evidenceById.getReporterAccount());
+        assertNull(evidenceById.getEvidence().getReporterAccountId());
     }
 
     private void setReportAndEvidenceStatus(PlayerCharacterReport.Status status)


### PR DESCRIPTION
## Summary
- Reporter account (BattleTag) is now hidden from regular users in evidence responses, matching the existing moderator voter anonymization
- `clearSensitiveData` extended with a `LadderEvidence` overload that nulls `reporterAccountId` and `reporterAccount`; UI already renders "Anonymous" when `reporterAccount` is null

## Test plan
- [x] `whenNotInSecureRole_thenRemoveSensitiveData` asserts `reporterAccount` and `reporterAccountId` are null for both `/list` and `/list/{id}` endpoints
- [x] Full integration suite passes (`!GeneralSeleniumIT`)
- [x] Selenium suite passes (`GeneralSeleniumIT`)

closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)